### PR TITLE
Comprehensive Performance Profiler Module

### DIFF
--- a/.Build/F4SE/Plugins/Addictol.toml
+++ b/.Build/F4SE/Plugins/Addictol.toml
@@ -61,3 +61,14 @@ nMaxLockCount=8						    # Maximum allowable number of condition lock (Need bEsc
 bInteriorNavCutMultiThreading=true      # Enable InteriorNavCut MultiThreading, automatically disabled on Linux / Proton (needs bInteriorNavCut).
 nMaxPapyrusOpsPerFrame=500              # Maximum papyrus operations per frame. Higher number means better script performance on average.
 bIgnorePreInstallBias=false             # Ignore the previously preset value for texture quality distance, if this sets as false, should hopefully reduce the chance of causing rendering errors.
+
+[Profiler]
+bProfiler=true                          # Master toggle for the performance profiler. When false, all profiling is disabled.
+bESPProfiler=true                       # Profile ESP/ESM load times during CompileFiles.
+bESPSubHooks=false                      # Hook ConstructObjectList/InitAllForms for per-file timing. Requires calibrated call-site indices. Leave false until verified.
+bDLLProfiler=true                       # Profile F4SE DLL plugin load times via GetProcAddress IAT hook.
+bModuleProfiler=true                    # Profile Addictol internal module query/install times.
+bStartupTimeline=true                   # Record startup phase timeline markers.
+bMemoryTracking=true                    # Track memory usage snapshots at key lifecycle points.
+bBA2Timing=true                         # Time BA2 decompression calls (libdeflate).
+bCSVExport=true                         # Export profiler data to CSV alongside the log report.

--- a/Addictol/Include/AdProfilerBA2.h
+++ b/Addictol/Include/AdProfilerBA2.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <chrono>
+#include <atomic>
+
+#include <AdProfilerCore.h>
+
+namespace Addictol
+{
+	using namespace std::literals;
+
+	// Thread-safe BA2 decompression timing recorder.
+	// Records individual chunk-level decompression calls from the libdeflate hook
+	// and forwards them to ProfilerCore for aggregation and reporting.
+	class ProfilerBA2 :
+		public REX::Singleton<ProfilerBA2>
+	{
+		std::atomic<std::uint64_t> m_chunkCounter{ 0 };
+
+	public:
+		// Record a completed decompression operation with pre-measured timing.
+		// Thread-safe: called from multiple BA2 decompression worker threads.
+		//   a_compressedSize   - actual bytes consumed from the compressed stream
+		//   a_uncompressedSize - actual bytes produced into the output buffer
+		//   a_elapsedMs        - wall-clock milliseconds for the decompression call
+		void RecordDecompression(std::size_t a_compressedSize,
+			std::size_t a_uncompressedSize,
+			double a_elapsedMs) noexcept;
+	};
+}

--- a/Addictol/Include/AdProfilerBA2.h
+++ b/Addictol/Include/AdProfilerBA2.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <chrono>
 #include <atomic>
 
 #include <AdProfilerCore.h>

--- a/Addictol/Include/AdProfilerCore.h
+++ b/Addictol/Include/AdProfilerCore.h
@@ -131,6 +131,12 @@ namespace Addictol
 		void Start() noexcept;
 		[[nodiscard]] bool IsActive() const noexcept { return m_active; }
 		[[nodiscard]] static bool IsEnabledInConfig() noexcept;
+		[[nodiscard]] static bool IsESPEnabled() noexcept;
+		[[nodiscard]] static bool IsDLLEnabled() noexcept;
+		[[nodiscard]] static bool IsModuleProfilingEnabled() noexcept;
+		[[nodiscard]] static bool IsStartupTimelineEnabled() noexcept;
+		[[nodiscard]] static bool IsMemoryTrackingEnabled() noexcept;
+		[[nodiscard]] static bool IsBA2TimingEnabled() noexcept;
 
 		// Startup timeline
 		void MarkPhase(std::string_view a_name) noexcept;

--- a/Addictol/Include/AdProfilerCore.h
+++ b/Addictol/Include/AdProfilerCore.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <mutex>
+#include <atomic>
+#include <filesystem>
+
+#include <REX\REX\Singleton.h>
+#include <REX\REX\TOML.h>
+#include <REX\REX\LOG.h>
+
+namespace Addictol
+{
+	using namespace std::literals;
+
+	// High-resolution scoped timer that records elapsed milliseconds
+	class ScopedProfileTimer
+	{
+		std::chrono::high_resolution_clock::time_point m_start;
+		double& m_target;
+	public:
+		explicit ScopedProfileTimer(double& a_target) noexcept :
+			m_start(std::chrono::high_resolution_clock::now()),
+			m_target(a_target)
+		{}
+
+		~ScopedProfileTimer() noexcept
+		{
+			auto end = std::chrono::high_resolution_clock::now();
+			m_target = std::chrono::duration<double, std::milli>(end - m_start).count();
+		}
+	};
+
+	// Data structures for profiling results
+	struct ESPProfileEntry
+	{
+		std::string filename;
+		std::int32_t loadOrderIndex{ 0 };
+		double openMs{ 0.0 };
+		double constructMs{ 0.0 };
+		double closeMs{ 0.0 };
+		double totalMs{ 0.0 };
+	};
+
+	struct DLLProfileEntry
+	{
+		std::string dllName;
+		std::string dllPath;
+		double queryMs{ 0.0 };
+		double loadMs{ 0.0 };
+		std::string fileVersion;
+	};
+
+	struct ModuleProfileEntry
+	{
+		std::string moduleName;
+		double queryMs{ 0.0 };
+		double installMs{ 0.0 };
+		bool querySuccess{ false };
+		bool installSuccess{ false };
+	};
+
+	struct StartupPhase
+	{
+		std::string name;
+		std::chrono::high_resolution_clock::time_point timestamp;
+		double elapsedFromStartMs{ 0.0 };
+	};
+
+	struct MemorySnapshot
+	{
+		std::string phaseName;
+		std::size_t totalAllocated{ 0 };
+		std::size_t totalFreed{ 0 };
+		std::size_t peakUsage{ 0 };
+		std::size_t allocationCount{ 0 };
+	};
+
+	struct BA2ProfileEntry
+	{
+		std::string archiveName;
+		double decompressMs{ 0.0 };
+		std::size_t compressedSize{ 0 };
+		std::size_t uncompressedSize{ 0 };
+		double throughputMBps{ 0.0 };
+	};
+
+	// Central profiler data collector
+	class ProfilerCore :
+		public REX::Singleton<ProfilerCore>
+	{
+		std::chrono::high_resolution_clock::time_point m_startTime;
+		bool m_active{ false };
+
+		// ESP/ESM data
+		std::vector<ESPProfileEntry> m_espEntries;
+		double m_totalCompileMs{ 0.0 };
+		double m_initAllFormsMs{ 0.0 };
+		std::mutex m_espMutex;
+
+		// DLL data
+		std::vector<DLLProfileEntry> m_dllEntries;
+		std::mutex m_dllMutex;
+
+		// Module timing data
+		std::vector<ModuleProfileEntry> m_moduleEntries;
+		std::mutex m_moduleMutex;
+
+		// Startup timeline
+		std::vector<StartupPhase> m_startupPhases;
+		std::mutex m_startupMutex;
+
+		// Memory snapshots
+		std::vector<MemorySnapshot> m_memorySnapshots;
+		std::mutex m_memoryMutex;
+
+		// BA2 data
+		std::vector<BA2ProfileEntry> m_ba2Entries;
+		std::atomic<double> m_totalBA2DecompressMs{ 0.0 };
+		std::mutex m_ba2Mutex;
+
+		ProfilerCore(const ProfilerCore&) = delete;
+		ProfilerCore& operator=(const ProfilerCore&) = delete;
+	public:
+		ProfilerCore() = default;
+		virtual ~ProfilerCore() = default;
+
+		void Start() noexcept;
+		[[nodiscard]] bool IsActive() const noexcept { return m_active; }
+		[[nodiscard]] static bool IsEnabledInConfig() noexcept;
+
+		// Startup timeline
+		void MarkPhase(std::string_view a_name) noexcept;
+
+		// ESP/ESM profiling
+		void AddESPEntry(ESPProfileEntry&& a_entry) noexcept;
+		void SetTotalCompileTime(double a_ms) noexcept { m_totalCompileMs = a_ms; }
+		void SetInitAllFormsTime(double a_ms) noexcept { m_initAllFormsMs = a_ms; }
+
+		// DLL profiling
+		void AddDLLEntry(DLLProfileEntry&& a_entry) noexcept;
+
+		// Module profiling
+		void AddModuleEntry(ModuleProfileEntry&& a_entry) noexcept;
+
+		// Memory tracking
+		void AddMemorySnapshot(MemorySnapshot&& a_snapshot) noexcept;
+
+		// BA2 timing
+		void AddBA2Entry(BA2ProfileEntry&& a_entry) noexcept;
+
+		// Report generation
+		void GenerateReport() noexcept;
+		void ExportCSV() noexcept;
+
+		// Accessors
+		[[nodiscard]] const std::vector<ESPProfileEntry>& GetESPEntries() const noexcept { return m_espEntries; }
+		[[nodiscard]] const std::vector<DLLProfileEntry>& GetDLLEntries() const noexcept { return m_dllEntries; }
+		[[nodiscard]] const std::vector<ModuleProfileEntry>& GetModuleEntries() const noexcept { return m_moduleEntries; }
+		[[nodiscard]] const std::vector<StartupPhase>& GetStartupPhases() const noexcept { return m_startupPhases; }
+		[[nodiscard]] const std::vector<BA2ProfileEntry>& GetBA2Entries() const noexcept { return m_ba2Entries; }
+
+	private:
+		[[nodiscard]] std::string GetOutputDir() const noexcept;
+		void LogESPReport() noexcept;
+		void LogDLLReport() noexcept;
+		void LogModuleReport() noexcept;
+		void LogStartupTimeline() noexcept;
+		void LogMemoryReport() noexcept;
+		void LogBA2Report() noexcept;
+	};
+}

--- a/Addictol/Include/AdProfilerCore.h
+++ b/Addictol/Include/AdProfilerCore.h
@@ -119,7 +119,6 @@ namespace Addictol
 
 		// BA2 data
 		std::vector<BA2ProfileEntry> m_ba2Entries;
-		std::atomic<double> m_totalBA2DecompressMs{ 0.0 };
 		std::mutex m_ba2Mutex;
 
 		ProfilerCore(const ProfilerCore&) = delete;

--- a/Addictol/Include/AdProfilerDLL.h
+++ b/Addictol/Include/AdProfilerDLL.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+
+#include <REX\REX\Singleton.h>
+#include <REX\REX\LOG.h>
+#include <F4SE\F4SE.h>
+
+namespace Addictol
+{
+	using namespace std::literals;
+
+	// Hooks GetProcAddress in F4SE's import address table to transparently
+	// time every other F4SE plugin's F4SEPlugin_Query and F4SEPlugin_Load
+	// calls.  Must be installed during the preload stage so the hook is in
+	// place before F4SE begins dispatching Load calls to other plugins.
+	//
+	// Thread-safety: F4SE processes plugins sequentially on the main thread,
+	// so the hook uses simple static state with no locking.
+	class ProfilerDLL :
+		public REX::Singleton<ProfilerDLL>
+	{
+		bool m_installed{ false };
+
+		ProfilerDLL(const ProfilerDLL&) = delete;
+		ProfilerDLL& operator=(const ProfilerDLL&) = delete;
+	public:
+		ProfilerDLL() = default;
+		virtual ~ProfilerDLL() = default;
+
+		// Hook GetProcAddress in F4SE's IAT.
+		//
+		// a_f4se  The F4SE interface pointer received during plugin init.
+		//         Used solely to resolve F4SE's HMODULE via
+		//         GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS).
+		//         A PreLoadInterface* reinterpret_cast'd to LoadInterface*
+		//         is valid here -- only the address matters.
+		void Install(const F4SE::LoadInterface* a_f4se) noexcept;
+
+		// Returns true after a successful Install().
+		[[nodiscard]] bool IsInstalled() const noexcept { return m_installed; }
+
+		// Extract a "major.minor.build.sub" file-version string from a PE
+		// image on disk.  Returns an empty string on any failure.
+		[[nodiscard]] static std::string GetFileVersionString(const char* a_path) noexcept;
+	};
+}

--- a/Addictol/Include/AdProfilerESP.h
+++ b/Addictol/Include/AdProfilerESP.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <REX\REX\Singleton.h>
+
+namespace Addictol
+{
+	using namespace std::literals;
+
+	// Profiles ESP/ESM file loading times by hooking TESDataHandler functions.
+	// Hooks CompileFiles (total), ConstructObjectList (per-file), and InitAllForms.
+	// Results are fed to ProfilerCore for aggregation and reporting.
+	class ESPProfiler :
+		public REX::Singleton<ESPProfiler>
+	{
+	public:
+		// Describes a resolved CALL (E8 rel32) instruction found during function body scanning
+		struct CallSiteInfo
+		{
+			uintptr_t site{ 0 };      // Address of the E8 opcode byte
+			uintptr_t target{ 0 };    // Resolved absolute call target
+			std::size_t offset{ 0 };  // Byte offset from the scanned function's entry point
+		};
+
+	private:
+		bool m_installed{ false };
+		std::int32_t m_currentFileIndex{ 0 };
+
+		// --- Original function pointers (set by Detours during Install) ---
+
+		// TESDataHandler::CompileFiles
+		// Loads all ESP/ESM files in the load order. Wraps the entire compilation phase.
+		// OG: REL::ID(57137), NG: see kCompileFilesID_NG
+		// bool __fastcall CompileFiles(TESDataHandler* this)
+		static inline bool(__fastcall* OriginalCompileFiles)(void*) = nullptr;
+
+		// TESDataHandler::ConstructObjectList
+		// Per-file: reads all records from a single TESFile. The heaviest per-file phase.
+		// No address library ID — discovered by scanning CompileFiles for call-sites.
+		// void __fastcall ConstructObjectList(TESDataHandler* this, TESFile* a_file)
+		static inline void(__fastcall* OriginalConstructObjectList)(void*, void*) = nullptr;
+
+		// TESDataHandler::InitAllForms
+		// Post-load: resolves cross-references and initializes all loaded forms.
+		// No address library ID — discovered by scanning CompileFiles for call-sites.
+		// void __fastcall InitAllForms(TESDataHandler* this)
+		static inline void(__fastcall* OriginalInitAllForms)(void*) = nullptr;
+
+		ESPProfiler(const ESPProfiler&) = delete;
+		ESPProfiler& operator=(const ESPProfiler&) = delete;
+
+		// --- Hook implementations ---
+		static bool __fastcall HookCompileFiles(void* a_this) noexcept;
+		static void __fastcall HookConstructObjectList(void* a_this, void* a_file) noexcept;
+		static void __fastcall HookInitAllForms(void* a_this) noexcept;
+
+		// --- Utilities ---
+
+		// Extracts the filename from a TESFile* using SEH-protected memory access.
+		// TESFile::filename is an inline char[260] at offset +0x70.
+		[[nodiscard]] static const char* GetTESFileName(void* a_file) noexcept;
+
+		// Scans a function body for near CALL (E8 rel32) instructions.
+		// Returns all resolved call sites within the scan window.
+		[[nodiscard]] static std::vector<CallSiteInfo> ScanCallSites(
+			uintptr_t a_funcBase, std::size_t a_maxBytes) noexcept;
+
+	public:
+		ESPProfiler() = default;
+		virtual ~ESPProfiler() = default;
+
+		// Installs all ESP profiling hooks. Requires ProfilerCore to be active.
+		// Safe to call multiple times (no-op after first successful install).
+		void Install() noexcept;
+
+		// Returns true if hooks were successfully installed.
+		[[nodiscard]] bool IsInstalled() const noexcept { return m_installed; }
+	};
+}

--- a/Addictol/Include/AdProfilerESP.h
+++ b/Addictol/Include/AdProfilerESP.h
@@ -38,14 +38,14 @@ namespace Addictol
 
 		// TESDataHandler::ConstructObjectList
 		// Per-file: reads all records from a single TESFile. The heaviest per-file phase.
-		// No address library ID — discovered by scanning CompileFiles for call-sites.
-		// void __fastcall ConstructObjectList(TESDataHandler* this, TESFile* a_file)
-		static inline void(__fastcall* OriginalConstructObjectList)(void*, void*) = nullptr;
+		// No address library ID — resolved via known RVA from Ghidra/F4LoadTimeProfiler.
+		// void __fastcall ConstructObjectList(TESDataHandler*, TESFile*, bool, void*)
+		static inline void(__fastcall* OriginalConstructObjectList)(void*, void*, bool, void*) = nullptr;
 
 		// TESDataHandler::InitAllForms
 		// Post-load: resolves cross-references and initializes all loaded forms.
-		// No address library ID — discovered by scanning CompileFiles for call-sites.
-		// void __fastcall InitAllForms(TESDataHandler* this)
+		// No address library ID — resolved via known RVA from Ghidra/F4LoadTimeProfiler.
+		// void __fastcall InitAllForms(TESDataHandler*)
 		static inline void(__fastcall* OriginalInitAllForms)(void*) = nullptr;
 
 		ESPProfiler(const ESPProfiler&) = delete;
@@ -53,7 +53,7 @@ namespace Addictol
 
 		// --- Hook implementations ---
 		static bool __fastcall HookCompileFiles(void* a_this) noexcept;
-		static void __fastcall HookConstructObjectList(void* a_this, void* a_file) noexcept;
+		static void __fastcall HookConstructObjectList(void* a_this, void* a_file, bool a_isFirst, void* a_param4) noexcept;
 		static void __fastcall HookInitAllForms(void* a_this) noexcept;
 
 		// --- Utilities ---

--- a/Addictol/Include/AdProfilerESP.h
+++ b/Addictol/Include/AdProfilerESP.h
@@ -32,7 +32,7 @@ namespace Addictol
 
 		// TESDataHandler::CompileFiles
 		// Loads all ESP/ESM files in the load order. Wraps the entire compilation phase.
-		// OG: REL::ID(57137), NG: see kCompileFilesID_NG
+		// OG: REL::ID(57137), NG: direct RVA (0x2E6C50)
 		// bool __fastcall CompileFiles(TESDataHandler* this)
 		static inline bool(__fastcall* OriginalCompileFiles)(void*) = nullptr;
 

--- a/Addictol/Include/AdProfilerMemory.h
+++ b/Addictol/Include/AdProfilerMemory.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string_view>
+
+#include <REX\REX\Singleton.h>
+#include <REX\REX\LOG.h>
+
+namespace Addictol
+{
+	using namespace std::literals;
+
+	// Per-phase process memory tracker using Windows Process Memory APIs.
+	// Captures WorkingSetSize, PagefileUsage, and PeakWorkingSetSize
+	// from GetProcessMemoryInfo() at each loading phase, computing
+	// deltas from a recorded baseline.
+	//
+	// MemorySnapshot field mapping (process-level, not per-allocation):
+	//   totalAllocated  = WorkingSetSize     (current physical memory)
+	//   totalFreed      = PagefileUsage      (committed virtual memory)
+	//   peakUsage       = PeakWorkingSetSize (peak physical memory)
+	//   allocationCount = WorkingSetSize delta from baseline (net growth)
+	class ProfilerMemory :
+		public REX::Singleton<ProfilerMemory>
+	{
+		std::size_t m_baselineWorkingSet{ 0 };
+		std::size_t m_baselinePagefile{ 0 };
+		std::size_t m_baselinePeak{ 0 };
+		bool m_baselineCaptured{ false };
+
+		ProfilerMemory(const ProfilerMemory&) = delete;
+		ProfilerMemory& operator=(const ProfilerMemory&) = delete;
+	public:
+		ProfilerMemory() = default;
+		virtual ~ProfilerMemory() = default;
+
+		// Record the current process memory state as the baseline.
+		// Also submits a "Baseline" snapshot to ProfilerCore.
+		void CaptureBaseline() noexcept;
+
+		// Capture a snapshot at the named phase, computing deltas
+		// from baseline, and submit it to ProfilerCore.
+		void CaptureSnapshot(std::string_view a_phaseName) noexcept;
+
+		// Accessors
+		[[nodiscard]] bool HasBaseline() const noexcept { return m_baselineCaptured; }
+		[[nodiscard]] std::size_t GetBaselineWorkingSet() const noexcept { return m_baselineWorkingSet; }
+	};
+}

--- a/Addictol/Include/AdProfilerModules.h
+++ b/Addictol/Include/AdProfilerModules.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string_view>
+
+namespace Addictol
+{
+	// Module profiling instrumentation for ModuleManager.
+	// These free functions bracket SafeQueryMod/SafeInstallMod calls
+	// to time each Addictol module's initialization phases.
+	// All functions are no-ops when the profiler is inactive.
+
+	void ProfilerBeginModuleQuery(std::string_view a_name) noexcept;
+	void ProfilerEndModuleQuery(std::string_view a_name, bool a_success) noexcept;
+	void ProfilerBeginModuleInstall(std::string_view a_name) noexcept;
+	void ProfilerEndModuleInstall(std::string_view a_name, bool a_success) noexcept;
+
+	// Submits any remaining pending module entries to ProfilerCore.
+	// Call after all query/install phases complete as a safety flush.
+	void ProfilerFlushModuleEntries() noexcept;
+}

--- a/Addictol/Include/Modules/AdModuleProfiler.h
+++ b/Addictol/Include/Modules/AdModuleProfiler.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <AdModule.h>
+
+namespace Addictol
+{
+	class ModuleProfiler :
+		public Module
+	{
+	public:
+		ModuleProfiler();
+		virtual ~ModuleProfiler() = default;
+
+		[[nodiscard]] virtual bool DoQuery() const noexcept override;
+		[[nodiscard]] virtual bool DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept override;
+	};
+}

--- a/Addictol/Source/AdModuleManager.cpp
+++ b/Addictol/Source/AdModuleManager.cpp
@@ -1,6 +1,7 @@
 #include <AdAssert.h>
 #include <AdUtils.h>
 #include <AdModuleManager.h>
+#include <AdProfilerModules.h>
 
 namespace Addictol
 {
@@ -23,12 +24,16 @@ namespace Addictol
 
 	bool ModuleManager::SafeQueryMod(const ModulePtr& a_mod)
 	{
+		ProfilerBeginModuleQuery(a_mod->GetName());
 		__try
 		{
-			return a_mod->DoQuery();
+			auto result = a_mod->DoQuery();
+			ProfilerEndModuleQuery(a_mod->GetName(), result);
+			return result;
 		}
 		__except (1)
 		{
+			ProfilerEndModuleQuery(a_mod->GetName(), false);
 			REX::ERROR("Module \"{}\": caught exception during query"sv, a_mod->GetName());
 			return false;
 		}
@@ -36,12 +41,16 @@ namespace Addictol
 
 	bool ModuleManager::SafeInstallMod(const ModulePtr& a_mod, F4SE::MessagingInterface::Message* a_msg)
 	{
+		ProfilerBeginModuleInstall(a_mod->GetName());
 		__try
 		{
-			return a_mod->DoInstall(a_msg);
+			auto result = a_mod->DoInstall(a_msg);
+			ProfilerEndModuleInstall(a_mod->GetName(), result);
+			return result;
 		}
 		__except (1)
 		{
+			ProfilerEndModuleInstall(a_mod->GetName(), false);
 			REX::ERROR("Module \"{}\": caught exception during install"sv, a_mod->GetName());
 			return false;
 		}

--- a/Addictol/Source/AdPlugin.cpp
+++ b/Addictol/Source/AdPlugin.cpp
@@ -1,5 +1,9 @@
 #include <AdPlugin.h>
 #include <AdUtils.h>
+#include <AdProfilerCore.h>
+#include <AdProfilerDLL.h>
+#include <AdProfilerMemory.h>
+#include <AdProfilerModules.h>
 
 #include <RE/B/BSScriptUtil.h>
 
@@ -18,8 +22,33 @@ namespace Addictol
 	static F4SE::Impl::F4SEInterface RestoreLoadInterface;
 #endif // SUPPORT_OG
 
+	[[nodiscard]] static const char* GetF4SEMessageName(std::uint32_t a_type) noexcept
+	{
+		switch (a_type)
+		{
+		case F4SE::MessagingInterface::kPostLoad:      return "PostLoad";
+		case F4SE::MessagingInterface::kPostPostLoad:  return "PostPostLoad";
+		case F4SE::MessagingInterface::kPreLoadGame:   return "PreLoadGame";
+		case F4SE::MessagingInterface::kPostLoadGame:  return "PostLoadGame";
+		case F4SE::MessagingInterface::kPreSaveGame:   return "PreSaveGame";
+		case F4SE::MessagingInterface::kPostSaveGame:  return "PostSaveGame";
+		case F4SE::MessagingInterface::kDeleteGame:    return "DeleteGame";
+		case F4SE::MessagingInterface::kInputLoaded:   return "InputLoaded";
+		case F4SE::MessagingInterface::kNewGame:       return "NewGame";
+		case F4SE::MessagingInterface::kGameLoaded:    return "GameLoaded";
+		case F4SE::MessagingInterface::kGameDataReady: return "GameDataReady";
+		default:                                       return "Unknown";
+		}
+	}
+
 	static void F4SEMessageListener(F4SE::MessagingInterface::Message* a_msg) noexcept
 	{
+		{
+			auto profiler = ProfilerCore::GetSingleton();
+			if (profiler->IsActive())
+				profiler->MarkPhase(std::string("F4SE_") + GetF4SEMessageName(a_msg->type));
+		}
+
 		auto plugin = Plugin::GetSingleton();
 		if (!plugin->IsInstall())
 		{
@@ -86,10 +115,22 @@ namespace Addictol
 				const auto config = REX::TOML::SettingStore::GetSingleton();
 				config->Init("Data/F4SE/Plugins/" _PluginName ".toml", "Data/F4SE/Plugins/" _PluginName "Custom.toml");
 				config->Load();
+				ProfilerCore::GetSingleton()->MarkPhase("ConfigLoaded"sv);
+
+				// Early profiler start: install DLL profiler before other modules load
+				if (ProfilerCore::IsEnabledInConfig())
+				{
+					auto profiler = ProfilerCore::GetSingleton();
+					if (!profiler->IsActive())
+						profiler->Start();
+					ProfilerDLL::GetSingleton()->Install(a_f4se);
+					ProfilerMemory::GetSingleton()->CaptureBaseline();
+				}
 			}
 
 			// Register all modules
 			AdRegisterModules();
+			ProfilerCore::GetSingleton()->MarkPhase("ModulesRegistered"sv);
 
 			// Listen for Messages (to Install PostInit Patches)
 			auto MessagingInterface = F4SE::GetMessagingInterface();
@@ -105,7 +146,11 @@ namespace Addictol
 
 			// Install load patches
 			moduleManager.QueryLoadAll();
+			ProfilerCore::GetSingleton()->MarkPhase("ModulesQueried"sv);
 			moduleManager.InstallLoadAll();
+			ProfilerCore::GetSingleton()->MarkPhase("ModulesInstalled"sv);
+			ProfilerFlushModuleEntries();
+			ProfilerMemory::GetSingleton()->CaptureSnapshot("AfterModuleInstall"sv);
 
 			isInit = true;
 		});
@@ -138,12 +183,17 @@ namespace Addictol
 			const auto config = REX::TOML::SettingStore::GetSingleton();
 			config->Init("Data/F4SE/Plugins/" _PluginName ".toml", "Data/F4SE/Plugins/" _PluginName "Custom.toml");
 			config->Load();
+			ProfilerCore::GetSingleton()->MarkPhase("PreloadConfigLoaded"sv);
 
 			AdRegisterPreloadModules();
+			ProfilerCore::GetSingleton()->MarkPhase("PreloadModulesRegistered"sv);
 
 			// Install preload patches
 			moduleManager.QueryPreloadAll();
+			ProfilerCore::GetSingleton()->MarkPhase("PreloadModulesQueried"sv);
 			moduleManager.InstallPreloadAll();
+			ProfilerCore::GetSingleton()->MarkPhase("PreloadModulesInstalled"sv);
+			ProfilerFlushModuleEntries();
 
 			isPreloadInit = true;
 		});

--- a/Addictol/Source/AdPlugin.cpp
+++ b/Addictol/Source/AdPlugin.cpp
@@ -115,7 +115,6 @@ namespace Addictol
 				const auto config = REX::TOML::SettingStore::GetSingleton();
 				config->Init("Data/F4SE/Plugins/" _PluginName ".toml", "Data/F4SE/Plugins/" _PluginName "Custom.toml");
 				config->Load();
-				ProfilerCore::GetSingleton()->MarkPhase("ConfigLoaded"sv);
 
 				// Early profiler start: install DLL profiler before other modules load
 				if (ProfilerCore::IsEnabledInConfig())
@@ -123,6 +122,7 @@ namespace Addictol
 					auto profiler = ProfilerCore::GetSingleton();
 					if (!profiler->IsActive())
 						profiler->Start();
+					profiler->MarkPhase("ConfigLoaded"sv);
 					if (ProfilerCore::IsDLLEnabled())
 						ProfilerDLL::GetSingleton()->Install(a_f4se);
 					if (ProfilerCore::IsMemoryTrackingEnabled())

--- a/Addictol/Source/AdPlugin.cpp
+++ b/Addictol/Source/AdPlugin.cpp
@@ -123,8 +123,10 @@ namespace Addictol
 					auto profiler = ProfilerCore::GetSingleton();
 					if (!profiler->IsActive())
 						profiler->Start();
-					ProfilerDLL::GetSingleton()->Install(a_f4se);
-					ProfilerMemory::GetSingleton()->CaptureBaseline();
+					if (ProfilerCore::IsDLLEnabled())
+						ProfilerDLL::GetSingleton()->Install(a_f4se);
+					if (ProfilerCore::IsMemoryTrackingEnabled())
+						ProfilerMemory::GetSingleton()->CaptureBaseline();
 				}
 			}
 
@@ -150,7 +152,8 @@ namespace Addictol
 			moduleManager.InstallLoadAll();
 			ProfilerCore::GetSingleton()->MarkPhase("ModulesInstalled"sv);
 			ProfilerFlushModuleEntries();
-			ProfilerMemory::GetSingleton()->CaptureSnapshot("AfterModuleInstall"sv);
+			if (ProfilerCore::IsMemoryTrackingEnabled())
+				ProfilerMemory::GetSingleton()->CaptureSnapshot("AfterModuleInstall"sv);
 
 			isInit = true;
 		});

--- a/Addictol/Source/AdProfilerBA2.cpp
+++ b/Addictol/Source/AdProfilerBA2.cpp
@@ -1,0 +1,33 @@
+#include <AdProfilerBA2.h>
+
+namespace Addictol
+{
+	void ProfilerBA2::RecordDecompression(std::size_t a_compressedSize,
+		std::size_t a_uncompressedSize,
+		double a_elapsedMs) noexcept
+	{
+		auto* profiler = ProfilerCore::GetSingleton();
+		if (!profiler || !profiler->IsActive())
+			return;
+
+		// Throughput: (uncompressed MB) / (elapsed seconds)
+		double throughputMBps = 0.0;
+		if (a_elapsedMs > 0.0)
+		{
+			double uncompressedMB = static_cast<double>(a_uncompressedSize) / (1024.0 * 1024.0);
+			double elapsedSec = a_elapsedMs / 1000.0;
+			throughputMBps = uncompressedMB / elapsedSec;
+		}
+
+		auto chunkId = m_chunkCounter.fetch_add(1, std::memory_order_relaxed);
+
+		BA2ProfileEntry entry;
+		entry.archiveName = "chunk_" + std::to_string(chunkId);
+		entry.decompressMs = a_elapsedMs;
+		entry.compressedSize = a_compressedSize;
+		entry.uncompressedSize = a_uncompressedSize;
+		entry.throughputMBps = throughputMBps;
+
+		profiler->AddBA2Entry(std::move(entry));
+	}
+}

--- a/Addictol/Source/AdProfilerCore.cpp
+++ b/Addictol/Source/AdProfilerCore.cpp
@@ -11,7 +11,7 @@ namespace Addictol
 {
 	// TOML config options for the profiler
 	static REX::TOML::Bool<> bProfiler{ "Profiler"sv, "bProfiler"sv, false };
-	static REX::TOML::Bool<> bESPProfiler{ "Profiler"sv, "bESPProfiler"sv, false };
+	static REX::TOML::Bool<> bESPProfiler{ "Profiler"sv, "bESPProfiler"sv, true };
 	static REX::TOML::Bool<> bDLLProfiler{ "Profiler"sv, "bDLLProfiler"sv, true };
 	static REX::TOML::Bool<> bModuleProfiler{ "Profiler"sv, "bModuleProfiler"sv, true };
 	static REX::TOML::Bool<> bStartupTimeline{ "Profiler"sv, "bStartupTimeline"sv, true };

--- a/Addictol/Source/AdProfilerCore.cpp
+++ b/Addictol/Source/AdProfilerCore.cpp
@@ -1,0 +1,412 @@
+#include <AdProfilerCore.h>
+#include <AdUtils.h>
+
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <algorithm>
+#include <ctime>
+
+namespace Addictol
+{
+	// TOML config options for the profiler
+	static REX::TOML::Bool<> bProfiler{ "Profiler"sv, "bProfiler"sv, false };
+	static REX::TOML::Bool<> bESPProfiler{ "Profiler"sv, "bESPProfiler"sv, true };
+	static REX::TOML::Bool<> bDLLProfiler{ "Profiler"sv, "bDLLProfiler"sv, true };
+	static REX::TOML::Bool<> bModuleProfiler{ "Profiler"sv, "bModuleProfiler"sv, true };
+	static REX::TOML::Bool<> bStartupTimeline{ "Profiler"sv, "bStartupTimeline"sv, true };
+	static REX::TOML::Bool<> bMemoryTracking{ "Profiler"sv, "bMemoryTracking"sv, true };
+	static REX::TOML::Bool<> bBA2Timing{ "Profiler"sv, "bBA2Timing"sv, true };
+	static REX::TOML::Bool<> bCSVExport{ "Profiler"sv, "bCSVExport"sv, true };
+
+	void ProfilerCore::Start() noexcept
+	{
+		m_startTime = std::chrono::high_resolution_clock::now();
+		m_active = true;
+		MarkPhase("ProfilerStart"sv);
+		REX::INFO("[Profiler] Performance profiler started"sv);
+	}
+
+	bool ProfilerCore::IsEnabledInConfig() noexcept
+	{
+		return bProfiler.GetValue();
+	}
+
+	void ProfilerCore::MarkPhase(std::string_view a_name) noexcept
+	{
+		if (!m_active)
+			return;
+
+		auto now = std::chrono::high_resolution_clock::now();
+		double elapsed = std::chrono::duration<double, std::milli>(now - m_startTime).count();
+
+		std::lock_guard lock(m_startupMutex);
+		m_startupPhases.push_back({ std::string(a_name), now, elapsed });
+	}
+
+	void ProfilerCore::AddESPEntry(ESPProfileEntry&& a_entry) noexcept
+	{
+		if (!m_active)
+			return;
+
+		std::lock_guard lock(m_espMutex);
+		m_espEntries.push_back(std::move(a_entry));
+	}
+
+	void ProfilerCore::AddDLLEntry(DLLProfileEntry&& a_entry) noexcept
+	{
+		if (!m_active)
+			return;
+
+		std::lock_guard lock(m_dllMutex);
+		m_dllEntries.push_back(std::move(a_entry));
+	}
+
+	void ProfilerCore::AddModuleEntry(ModuleProfileEntry&& a_entry) noexcept
+	{
+		if (!m_active)
+			return;
+
+		std::lock_guard lock(m_moduleMutex);
+		m_moduleEntries.push_back(std::move(a_entry));
+	}
+
+	void ProfilerCore::AddMemorySnapshot(MemorySnapshot&& a_snapshot) noexcept
+	{
+		if (!m_active)
+			return;
+
+		std::lock_guard lock(m_memoryMutex);
+		m_memorySnapshots.push_back(std::move(a_snapshot));
+	}
+
+	void ProfilerCore::AddBA2Entry(BA2ProfileEntry&& a_entry) noexcept
+	{
+		if (!m_active)
+			return;
+
+		std::lock_guard lock(m_ba2Mutex);
+		m_ba2Entries.push_back(std::move(a_entry));
+	}
+
+	// -- Report Generation --
+
+	std::string ProfilerCore::GetOutputDir() const noexcept
+	{
+		std::string dir = AdGetRuntimeDirectory() + "Data\\F4SE\\Plugins\\Addictol\\Profiler\\";
+
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+
+		return dir;
+	}
+
+	void ProfilerCore::LogESPReport() noexcept
+	{
+		if (m_espEntries.empty())
+			return;
+
+		REX::INFO("[Profiler] ===== ESP/ESM Load Time Report ====="sv);
+		REX::INFO("[Profiler]   Total CompileFiles: {:.1f} ms ({:.2f} s)"sv, m_totalCompileMs, m_totalCompileMs / 1000.0);
+		REX::INFO("[Profiler]   InitAllForms: {:.1f} ms"sv, m_initAllFormsMs);
+		REX::INFO("[Profiler]   Files loaded: {}"sv, m_espEntries.size());
+
+		// Sort by construct time descending for the report
+		auto sorted = m_espEntries;
+		std::sort(sorted.begin(), sorted.end(),
+			[](const auto& a, const auto& b) { return a.constructMs > b.constructMs; });
+
+		REX::INFO("[Profiler]   --- Top files by load time ---"sv);
+		std::size_t reportCount = std::min(sorted.size(), static_cast<std::size_t>(20));
+		for (std::size_t i = 0; i < reportCount; ++i)
+		{
+			const auto& e = sorted[i];
+			REX::INFO("[Profiler]   [{:3d}] {:40s} {:8.1f} ms (open: {:.1f}, construct: {:.1f}, close: {:.1f})"sv,
+				e.loadOrderIndex, e.filename, e.totalMs, e.openMs, e.constructMs, e.closeMs);
+		}
+	}
+
+	void ProfilerCore::LogDLLReport() noexcept
+	{
+		if (m_dllEntries.empty())
+			return;
+
+		REX::INFO("[Profiler] ===== F4SE Plugin DLL Load Time Report ====="sv);
+
+		double totalLoad = 0.0, totalQuery = 0.0;
+		for (const auto& e : m_dllEntries)
+		{
+			totalLoad += e.loadMs;
+			totalQuery += e.queryMs;
+		}
+
+		REX::INFO("[Profiler]   Plugins loaded: {}"sv, m_dllEntries.size());
+		REX::INFO("[Profiler]   Total Query time: {:.1f} ms"sv, totalQuery);
+		REX::INFO("[Profiler]   Total Load time: {:.1f} ms"sv, totalLoad);
+
+		// Sort by load time descending
+		auto sorted = m_dllEntries;
+		std::sort(sorted.begin(), sorted.end(),
+			[](const auto& a, const auto& b) { return a.loadMs > b.loadMs; });
+
+		for (const auto& e : sorted)
+		{
+			REX::INFO("[Profiler]   {:40s} Load: {:8.1f} ms  Query: {:6.1f} ms  Ver: {}"sv,
+				e.dllName, e.loadMs, e.queryMs,
+				e.fileVersion.empty() ? "(none)"sv : std::string_view(e.fileVersion));
+		}
+	}
+
+	void ProfilerCore::LogModuleReport() noexcept
+	{
+		if (m_moduleEntries.empty())
+			return;
+
+		REX::INFO("[Profiler] ===== Addictol Module Init Time Report ====="sv);
+
+		double totalQuery = 0.0, totalInstall = 0.0;
+		for (const auto& e : m_moduleEntries)
+		{
+			totalQuery += e.queryMs;
+			totalInstall += e.installMs;
+		}
+
+		REX::INFO("[Profiler]   Modules: {}"sv, m_moduleEntries.size());
+		REX::INFO("[Profiler]   Total Query time: {:.3f} ms"sv, totalQuery);
+		REX::INFO("[Profiler]   Total Install time: {:.3f} ms"sv, totalInstall);
+
+		// Sort by install time descending
+		auto sorted = m_moduleEntries;
+		std::sort(sorted.begin(), sorted.end(),
+			[](const auto& a, const auto& b) { return a.installMs > b.installMs; });
+
+		for (const auto& e : sorted)
+		{
+			REX::INFO("[Profiler]   {:30s} Query: {:8.3f} ms ({})  Install: {:8.3f} ms ({})"sv,
+				e.moduleName, e.queryMs, e.querySuccess ? "ok" : "FAIL",
+				e.installMs, e.installSuccess ? "ok" : "FAIL");
+		}
+	}
+
+	void ProfilerCore::LogStartupTimeline() noexcept
+	{
+		if (m_startupPhases.empty())
+			return;
+
+		REX::INFO("[Profiler] ===== Startup Timeline ====="sv);
+		for (std::size_t i = 0; i < m_startupPhases.size(); ++i)
+		{
+			const auto& phase = m_startupPhases[i];
+			double deltaMs = 0.0;
+			if (i > 0)
+				deltaMs = phase.elapsedFromStartMs - m_startupPhases[i - 1].elapsedFromStartMs;
+
+			REX::INFO("[Profiler]   [{:8.1f} ms] {:30s} (delta: {:8.1f} ms)"sv,
+				phase.elapsedFromStartMs, phase.name, deltaMs);
+		}
+	}
+
+	void ProfilerCore::LogMemoryReport() noexcept
+	{
+		if (m_memorySnapshots.empty())
+			return;
+
+		REX::INFO("[Profiler] ===== Memory Usage Report ====="sv);
+		for (const auto& snap : m_memorySnapshots)
+		{
+			REX::INFO("[Profiler]   {:30s} Alloc: {:>10} bytes  Freed: {:>10} bytes  Peak: {:>10} bytes  Count: {}"sv,
+				snap.phaseName, snap.totalAllocated, snap.totalFreed, snap.peakUsage, snap.allocationCount);
+		}
+	}
+
+	void ProfilerCore::LogBA2Report() noexcept
+	{
+		if (m_ba2Entries.empty())
+			return;
+
+		REX::INFO("[Profiler] ===== BA2 Decompression Report ====="sv);
+
+		double totalMs = 0.0;
+		std::size_t totalCompressed = 0, totalUncompressed = 0;
+		for (const auto& e : m_ba2Entries)
+		{
+			totalMs += e.decompressMs;
+			totalCompressed += e.compressedSize;
+			totalUncompressed += e.uncompressedSize;
+		}
+
+		double totalMBps = totalMs > 0.0 ? (static_cast<double>(totalUncompressed) / (1024.0 * 1024.0)) / (totalMs / 1000.0) : 0.0;
+
+		REX::INFO("[Profiler]   Archives: {}"sv, m_ba2Entries.size());
+		REX::INFO("[Profiler]   Total decompress time: {:.1f} ms"sv, totalMs);
+		REX::INFO("[Profiler]   Total compressed: {:.2f} MB"sv, static_cast<double>(totalCompressed) / (1024.0 * 1024.0));
+		REX::INFO("[Profiler]   Total uncompressed: {:.2f} MB"sv, static_cast<double>(totalUncompressed) / (1024.0 * 1024.0));
+		REX::INFO("[Profiler]   Average throughput: {:.1f} MB/s"sv, totalMBps);
+
+		// Sort by decompress time descending
+		auto sorted = m_ba2Entries;
+		std::sort(sorted.begin(), sorted.end(),
+			[](const auto& a, const auto& b) { return a.decompressMs > b.decompressMs; });
+
+		std::size_t reportCount = std::min(sorted.size(), static_cast<std::size_t>(20));
+		for (std::size_t i = 0; i < reportCount; ++i)
+		{
+			const auto& e = sorted[i];
+			REX::INFO("[Profiler]   {:40s} {:8.1f} ms ({:.1f} MB/s)"sv,
+				e.archiveName, e.decompressMs, e.throughputMBps);
+		}
+	}
+
+	void ProfilerCore::GenerateReport() noexcept
+	{
+		if (!m_active)
+			return;
+
+		MarkPhase("ReportGeneration"sv);
+
+		REX::INFO("[Profiler] ========================================"sv);
+		REX::INFO("[Profiler]   ADDICTOL PERFORMANCE PROFILER REPORT"sv);
+		REX::INFO("[Profiler] ========================================"sv);
+
+		if (bStartupTimeline.GetValue())
+			LogStartupTimeline();
+		if (bDLLProfiler.GetValue())
+			LogDLLReport();
+		if (bESPProfiler.GetValue())
+			LogESPReport();
+		if (bModuleProfiler.GetValue())
+			LogModuleReport();
+		if (bMemoryTracking.GetValue())
+			LogMemoryReport();
+		if (bBA2Timing.GetValue())
+			LogBA2Report();
+
+		if (bCSVExport.GetValue())
+			ExportCSV();
+
+		REX::INFO("[Profiler] ========================================"sv);
+		REX::INFO("[Profiler]   END OF PROFILER REPORT"sv);
+		REX::INFO("[Profiler] ========================================"sv);
+	}
+
+	void ProfilerCore::ExportCSV() noexcept
+	{
+		auto dir = GetOutputDir();
+		if (dir.empty())
+			return;
+
+		// Timestamp for unique filenames
+		auto now = std::time(nullptr);
+		std::tm tm{};
+		localtime_s(&tm, &now);
+
+		char timeBuf[64];
+		std::strftime(timeBuf, sizeof(timeBuf), "%Y%m%d_%H%M%S", &tm);
+
+		// ESP/ESM CSV
+		if (!m_espEntries.empty())
+		{
+			std::string path = dir + "esp_load_times_" + timeBuf + ".csv";
+			std::ofstream file(path);
+			if (file.is_open())
+			{
+				file << "LoadOrder,Filename,OpenMs,ConstructMs,CloseMs,TotalMs\n";
+				for (const auto& e : m_espEntries)
+				{
+					file << e.loadOrderIndex << ","
+						<< "\"" << e.filename << "\","
+						<< std::fixed << std::setprecision(1)
+						<< e.openMs << ","
+						<< e.constructMs << ","
+						<< e.closeMs << ","
+						<< e.totalMs << "\n";
+				}
+				REX::INFO("[Profiler] ESP CSV exported: {}"sv, path);
+			}
+		}
+
+		// DLL CSV
+		if (!m_dllEntries.empty())
+		{
+			std::string path = dir + "dll_load_times_" + timeBuf + ".csv";
+			std::ofstream file(path);
+			if (file.is_open())
+			{
+				file << "DLLName,QueryMs,LoadMs,FileVersion,DLLPath\n";
+				for (const auto& e : m_dllEntries)
+				{
+					file << "\"" << e.dllName << "\","
+						<< std::fixed << std::setprecision(1)
+						<< e.queryMs << ","
+						<< e.loadMs << ","
+						<< "\"" << e.fileVersion << "\","
+						<< "\"" << e.dllPath << "\"\n";
+				}
+				REX::INFO("[Profiler] DLL CSV exported: {}"sv, path);
+			}
+		}
+
+		// Module CSV
+		if (!m_moduleEntries.empty())
+		{
+			std::string path = dir + "module_times_" + timeBuf + ".csv";
+			std::ofstream file(path);
+			if (file.is_open())
+			{
+				file << "ModuleName,QueryMs,QuerySuccess,InstallMs,InstallSuccess\n";
+				for (const auto& e : m_moduleEntries)
+				{
+					file << "\"" << e.moduleName << "\","
+						<< std::fixed << std::setprecision(3)
+						<< e.queryMs << ","
+						<< (e.querySuccess ? "true" : "false") << ","
+						<< e.installMs << ","
+						<< (e.installSuccess ? "true" : "false") << "\n";
+				}
+				REX::INFO("[Profiler] Module CSV exported: {}"sv, path);
+			}
+		}
+
+		// BA2 CSV
+		if (!m_ba2Entries.empty())
+		{
+			std::string path = dir + "ba2_decompress_times_" + timeBuf + ".csv";
+			std::ofstream file(path);
+			if (file.is_open())
+			{
+				file << "ArchiveName,DecompressMs,CompressedBytes,UncompressedBytes,ThroughputMBps\n";
+				for (const auto& e : m_ba2Entries)
+				{
+					file << "\"" << e.archiveName << "\","
+						<< std::fixed << std::setprecision(1)
+						<< e.decompressMs << ","
+						<< e.compressedSize << ","
+						<< e.uncompressedSize << ","
+						<< std::setprecision(1) << e.throughputMBps << "\n";
+				}
+				REX::INFO("[Profiler] BA2 CSV exported: {}"sv, path);
+			}
+		}
+
+		// Startup Timeline CSV
+		if (!m_startupPhases.empty())
+		{
+			std::string path = dir + "startup_timeline_" + timeBuf + ".csv";
+			std::ofstream file(path);
+			if (file.is_open())
+			{
+				file << "Phase,ElapsedMs,DeltaMs\n";
+				for (std::size_t i = 0; i < m_startupPhases.size(); ++i)
+				{
+					const auto& phase = m_startupPhases[i];
+					double delta = (i > 0) ? phase.elapsedFromStartMs - m_startupPhases[i - 1].elapsedFromStartMs : 0.0;
+					file << "\"" << phase.name << "\","
+						<< std::fixed << std::setprecision(1)
+						<< phase.elapsedFromStartMs << ","
+						<< delta << "\n";
+				}
+				REX::INFO("[Profiler] Startup timeline CSV exported: {}"sv, path);
+			}
+		}
+	}
+}

--- a/Addictol/Source/AdProfilerCore.cpp
+++ b/Addictol/Source/AdProfilerCore.cpp
@@ -11,7 +11,7 @@ namespace Addictol
 {
 	// TOML config options for the profiler
 	static REX::TOML::Bool<> bProfiler{ "Profiler"sv, "bProfiler"sv, false };
-	static REX::TOML::Bool<> bESPProfiler{ "Profiler"sv, "bESPProfiler"sv, true };
+	static REX::TOML::Bool<> bESPProfiler{ "Profiler"sv, "bESPProfiler"sv, false };
 	static REX::TOML::Bool<> bDLLProfiler{ "Profiler"sv, "bDLLProfiler"sv, true };
 	static REX::TOML::Bool<> bModuleProfiler{ "Profiler"sv, "bModuleProfiler"sv, true };
 	static REX::TOML::Bool<> bStartupTimeline{ "Profiler"sv, "bStartupTimeline"sv, true };
@@ -32,9 +32,39 @@ namespace Addictol
 		return bProfiler.GetValue();
 	}
 
+	bool ProfilerCore::IsESPEnabled() noexcept
+	{
+		return bESPProfiler.GetValue();
+	}
+
+	bool ProfilerCore::IsDLLEnabled() noexcept
+	{
+		return bDLLProfiler.GetValue();
+	}
+
+	bool ProfilerCore::IsModuleProfilingEnabled() noexcept
+	{
+		return bModuleProfiler.GetValue();
+	}
+
+	bool ProfilerCore::IsStartupTimelineEnabled() noexcept
+	{
+		return bStartupTimeline.GetValue();
+	}
+
+	bool ProfilerCore::IsMemoryTrackingEnabled() noexcept
+	{
+		return bMemoryTracking.GetValue();
+	}
+
+	bool ProfilerCore::IsBA2TimingEnabled() noexcept
+	{
+		return bBA2Timing.GetValue();
+	}
+
 	void ProfilerCore::MarkPhase(std::string_view a_name) noexcept
 	{
-		if (!m_active)
+		if (!m_active || !bStartupTimeline.GetValue())
 			return;
 
 		auto now = std::chrono::high_resolution_clock::now();

--- a/Addictol/Source/AdProfilerDLL.cpp
+++ b/Addictol/Source/AdProfilerDLL.cpp
@@ -1,0 +1,341 @@
+#include <AdProfilerDLL.h>
+#include <AdProfilerCore.h>
+#include <AdUtils.h>
+
+#include <Windows.h>
+
+// Resolve macro conflicts between Windows.h and CommonLibF4 identifiers.
+#undef ERROR
+#undef MEM_RELEASE
+#undef MAX_PATH
+#undef PAGE_EXECUTE_READWRITE
+
+#include <REX\W32\KERNEL32.h>
+#include <REX\W32\VERSION.h>
+
+#include <chrono>
+#include <cstring>
+#include <format>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace Addictol
+{
+	// ======================================================================
+	//  Static hook state
+	// ======================================================================
+	//
+	// F4SE processes plugins sequentially on the main thread:
+	//
+	//   Phase 1 (OG only) -- for each DLL: GetProcAddress("F4SEPlugin_Query")
+	//                        then call it, then next DLL.
+	//   Phase 2           -- for each DLL: GetProcAddress("F4SEPlugin_Load")
+	//                        then call it, then next DLL.
+	//
+	// Between a GetProcAddress return and the subsequent wrapper call, no
+	// other GetProcAddress for a plugin export can happen.  This lets us use
+	// simple static variables for the "currently active" context.
+	// ======================================================================
+
+	// Original kernel32!GetProcAddress, saved when the IAT hook is installed.
+	using GetProcAddress_t = FARPROC(WINAPI*)(HMODULE, LPCSTR);
+	static GetProcAddress_t s_origGetProcAddress = nullptr;
+
+	// Addictol's own HMODULE -- we skip self-profiling.
+	static HMODULE s_ownModule = nullptr;
+
+	// In-progress DLLProfileEntry objects, keyed by HMODULE.
+	// An entry is created when we first intercept a plugin export for a
+	// given module and is finalised (moved into ProfilerCore) once the
+	// Load wrapper completes.  The map is needed because OG F4SE queries
+	// ALL plugins before loading any, so Query and Load for the same DLL
+	// happen in separate phases.
+	static std::unordered_map<HMODULE, DLLProfileEntry> s_pendingEntries;
+
+	// Context for the wrapper that is *about* to be called.
+	// Set inside Hooked_GetProcAddress, consumed inside Wrapper_*.
+	static HMODULE s_activeModule = nullptr;
+	static FARPROC s_origQueryFn  = nullptr;
+	static FARPROC s_origLoadFn   = nullptr;
+
+	// ======================================================================
+	//  Helpers
+	// ======================================================================
+
+	static std::string GetModulePath(HMODULE a_module) noexcept
+	{
+		char buf[4096]{};
+		if (REX::W32::GetModuleFileNameA(
+			reinterpret_cast<REX::W32::HMODULE>(a_module), buf,
+			static_cast<std::uint32_t>(sizeof(buf))))
+		{
+			return buf;
+		}
+		return {};
+	}
+
+	static std::string ExtractFileName(const std::string& a_path) noexcept
+	{
+		auto pos = a_path.find_last_of("\\/");
+		return (pos != std::string::npos) ? a_path.substr(pos + 1) : a_path;
+	}
+
+	// Lazily populate a DLLProfileEntry for |a_module|.
+	static DLLProfileEntry& GetOrCreateEntry(HMODULE a_module) noexcept
+	{
+		auto it = s_pendingEntries.find(a_module);
+		if (it != s_pendingEntries.end())
+			return it->second;
+
+		auto path = GetModulePath(a_module);
+		auto name = ExtractFileName(path);
+		auto ver  = ProfilerDLL::GetFileVersionString(path.c_str());
+
+		auto& entry       = s_pendingEntries[a_module];
+		entry.dllName     = std::move(name);
+		entry.dllPath     = std::move(path);
+		entry.fileVersion = std::move(ver);
+		return entry;
+	}
+
+	// ======================================================================
+	//  Timing wrappers
+	// ======================================================================
+	//
+	// F4SE plugin export signatures (x64 -- single calling convention):
+	//
+	//   bool F4SEPlugin_Query(const F4SE::QueryInterface*, F4SE::PluginInfo*)
+	//   bool F4SEPlugin_Load (const F4SE::LoadInterface*)
+	//
+	// We use opaque void* parameters so the wrappers do not depend on the
+	// concrete F4SE interface types and can be cast to/from FARPROC freely.
+	// ======================================================================
+
+	static bool Wrapper_Query(const void* a_f4se, void* a_info) noexcept
+	{
+		// Capture context -- valid because F4SE is single-threaded here.
+		HMODULE mod    = s_activeModule;
+		auto    origFn = reinterpret_cast<bool(*)(const void*, void*)>(s_origQueryFn);
+
+		auto start  = std::chrono::high_resolution_clock::now();
+		bool result = origFn(a_f4se, a_info);
+		auto end    = std::chrono::high_resolution_clock::now();
+
+		double elapsed = std::chrono::duration<double, std::milli>(end - start).count();
+
+		auto it = s_pendingEntries.find(mod);
+		if (it != s_pendingEntries.end())
+		{
+			it->second.queryMs = elapsed;
+			REX::INFO("[Profiler] DLL Query: {} ({:.2f} ms)"sv,
+				it->second.dllName, elapsed);
+		}
+
+		return result;
+	}
+
+	static bool Wrapper_Load(const void* a_f4se) noexcept
+	{
+		HMODULE mod    = s_activeModule;
+		auto    origFn = reinterpret_cast<bool(*)(const void*)>(s_origLoadFn);
+
+		auto start  = std::chrono::high_resolution_clock::now();
+		bool result = origFn(a_f4se);
+		auto end    = std::chrono::high_resolution_clock::now();
+
+		double elapsed = std::chrono::duration<double, std::milli>(end - start).count();
+
+		auto it = s_pendingEntries.find(mod);
+		if (it != s_pendingEntries.end())
+		{
+			it->second.loadMs = elapsed;
+			REX::INFO("[Profiler] DLL Load: {} ({:.2f} ms)"sv,
+				it->second.dllName, elapsed);
+
+			// Finalise -- move completed entry into ProfilerCore.
+			ProfilerCore::GetSingleton()->AddDLLEntry(std::move(it->second));
+			s_pendingEntries.erase(it);
+		}
+
+		return result;
+	}
+
+	// ======================================================================
+	//  Hooked GetProcAddress
+	// ======================================================================
+	//
+	// This function replaces GetProcAddress in F4SE's import table.  Only
+	// calls originating from F4SE's own code are routed here -- other
+	// modules' IATs are unaffected.
+	//
+	// When F4SE resolves F4SEPlugin_Query or F4SEPlugin_Load, we return a
+	// timing wrapper instead of the raw function pointer.  All other
+	// lookups are forwarded to the original GetProcAddress unmodified.
+	// ======================================================================
+
+	static FARPROC WINAPI Hooked_GetProcAddress(HMODULE a_module, LPCSTR a_procName) noexcept
+	{
+		// Ordinal imports:  HIWORD == 0 means a_procName is an ordinal, not
+		// a string.  Pass through immediately.
+		if ((reinterpret_cast<std::uintptr_t>(a_procName) >> 16) == 0)
+			return s_origGetProcAddress(a_module, a_procName);
+
+		// Never profile our own module.
+		if (a_module == s_ownModule)
+			return s_origGetProcAddress(a_module, a_procName);
+
+		// --- F4SEPlugin_Query (OG path) ---------------------------------
+		if (std::strcmp(a_procName, "F4SEPlugin_Query") == 0)
+		{
+			FARPROC original = s_origGetProcAddress(a_module, a_procName);
+			if (original)
+			{
+				s_activeModule = a_module;
+				s_origQueryFn  = original;
+				GetOrCreateEntry(a_module);
+				return reinterpret_cast<FARPROC>(&Wrapper_Query);
+			}
+			return original; // nullptr -- DLL does not export this symbol
+		}
+
+		// --- F4SEPlugin_Load (OG and NG paths) --------------------------
+		if (std::strcmp(a_procName, "F4SEPlugin_Load") == 0)
+		{
+			FARPROC original = s_origGetProcAddress(a_module, a_procName);
+			if (original)
+			{
+				s_activeModule = a_module;
+				s_origLoadFn   = original;
+				GetOrCreateEntry(a_module);
+				return reinterpret_cast<FARPROC>(&Wrapper_Load);
+			}
+			return original;
+		}
+
+		// Everything else -- pass through unchanged.
+		return s_origGetProcAddress(a_module, a_procName);
+	}
+
+	// ======================================================================
+	//  Install
+	// ======================================================================
+
+	void ProfilerDLL::Install(const F4SE::LoadInterface* a_f4se) noexcept
+	{
+		if (m_installed)
+			return;
+
+		auto profiler = ProfilerCore::GetSingleton();
+		if (!profiler->IsActive())
+			return;
+
+		// ---- Resolve F4SE's HMODULE ------------------------------------
+		//
+		// The interface pointer passed by F4SE points to a global struct
+		// that resides inside the F4SE DLL's data section.  Using
+		// GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS lets us derive the
+		// owning module without knowing the DLL's file name.
+		HMODULE hF4SE = nullptr;
+		::GetModuleHandleExA(
+			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+			GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+			reinterpret_cast<LPCSTR>(a_f4se),
+			&hF4SE);
+
+		if (!hF4SE)
+		{
+			REX::WARN("[Profiler] DLL: Failed to resolve F4SE module handle"sv);
+			return;
+		}
+
+		// ---- Record our own HMODULE for self-skip ----------------------
+		::GetModuleHandleExA(
+			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+			GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+			reinterpret_cast<LPCSTR>(&Hooked_GetProcAddress),
+			&s_ownModule);
+
+		// ---- Hook GetProcAddress in F4SE's IAT -------------------------
+		//
+		// RELEX::DetourIAT walks the PE import directory of the target
+		// module (hF4SE), locates the IAT entry for kernel32!GetProcAddress,
+		// and overwrites it with our Hooked_GetProcAddress.  The return
+		// value is the original function pointer.
+		auto original = RELEX::DetourIAT(
+			reinterpret_cast<uintptr_t>(hF4SE),
+			"kernel32.dll",
+			"GetProcAddress",
+			reinterpret_cast<uintptr_t>(&Hooked_GetProcAddress));
+
+		if (!original)
+		{
+			REX::WARN("[Profiler] DLL: Failed to hook GetProcAddress in F4SE IAT"sv);
+			return;
+		}
+
+		s_origGetProcAddress = reinterpret_cast<GetProcAddress_t>(original);
+		m_installed = true;
+
+		REX::INFO("[Profiler] DLL: GetProcAddress hook installed in F4SE IAT"sv);
+		profiler->MarkPhase("DLLProfilerInstalled"sv);
+	}
+
+	// ======================================================================
+	//  Version extraction
+	// ======================================================================
+	//
+	// Queries the root VS_FIXEDFILEINFO block ("\\") of a PE file's
+	// version resource.  This is more reliable than the StringFileInfo
+	// approach because it does not depend on a specific language/codepage.
+	//
+	// The VS_FIXEDFILEINFO layout (all DWORD, naturally aligned):
+	//   [0] dwSignature           = 0xFEEF04BD
+	//   [1] dwStrucVersion
+	//   [2] dwFileVersionMS       = (major << 16) | minor
+	//   [3] dwFileVersionLS       = (build << 16) | sub
+	//   ... (remaining fields not needed)
+	// ======================================================================
+
+	std::string ProfilerDLL::GetFileVersionString(const char* a_path) noexcept
+	{
+		if (!a_path || !*a_path)
+			return {};
+
+		std::uint32_t dummy = 0;
+		std::uint32_t verSize = REX::W32::GetFileVersionInfoSizeA(a_path, &dummy);
+		if (!verSize)
+			return {};
+
+		auto verBuf = std::make_unique<char[]>(verSize);
+		if (!REX::W32::GetFileVersionInfoA(a_path, 0, verSize, verBuf.get()))
+			return {};
+
+		void*         infoPtr = nullptr;
+		std::uint32_t infoLen = 0;
+		if (!REX::W32::VerQueryValueA(verBuf.get(), "\\", &infoPtr, &infoLen))
+			return {};
+
+		// VS_FIXEDFILEINFO is 13 DWORDs (52 bytes).
+		constexpr std::uint32_t kFixedInfoMinSize = 52;
+		if (!infoPtr || infoLen < kFixedInfoMinSize)
+			return {};
+
+		auto info = static_cast<const std::uint32_t*>(infoPtr);
+
+		// Validate the magic signature.
+		constexpr std::uint32_t kSignature = 0xFEEF04BD;
+		if (info[0] != kSignature)
+			return {};
+
+		// info[2] = dwFileVersionMS,  info[3] = dwFileVersionLS
+		std::uint32_t ms = info[2];
+		std::uint32_t ls = info[3];
+
+		return std::format("{}.{}.{}.{}",
+			(ms >> 16) & 0xFFFF,
+			(ms)       & 0xFFFF,
+			(ls >> 16) & 0xFFFF,
+			(ls)       & 0xFFFF);
+	}
+}

--- a/Addictol/Source/AdProfilerESP.cpp
+++ b/Addictol/Source/AdProfilerESP.cpp
@@ -1,0 +1,419 @@
+#include <AdProfilerESP.h>
+#include <AdProfilerCore.h>
+#include <AdUtils.h>
+
+namespace
+{
+	using namespace Addictol;
+
+	// -----------------------------------------------------------------
+	// SEH-isolated helpers
+	// These must NOT contain local C++ objects with non-trivial destructors
+	// (MSVC C2712: Cannot use __try in functions that require object unwinding)
+	// -----------------------------------------------------------------
+
+	// Resolves a REL::ID to an absolute address, catching structured exceptions.
+	// Returns 0 on failure.
+	uintptr_t SafeResolveID(std::uint32_t a_id) noexcept
+	{
+		uintptr_t result = 0;
+		__try
+		{
+			result = REL::Relocation<uintptr_t>(REL::ID(a_id)).address();
+		}
+		__except (1)
+		{
+			result = 0;
+		}
+		return result;
+	}
+
+	// Scans memory starting at a_funcBase for E8 (near relative CALL) instructions.
+	// Writes resolved CallSiteInfo entries into a_outBuf (up to a_maxResults).
+	// Returns the number of valid call sites found.
+	std::size_t ScanCallSitesImpl(
+		uintptr_t a_funcBase, std::size_t a_maxBytes,
+		ESPProfiler::CallSiteInfo* a_outBuf, std::size_t a_maxResults) noexcept
+	{
+		std::size_t count = 0;
+
+		__try
+		{
+			for (std::size_t i = 0; i + 5 <= a_maxBytes && count < a_maxResults; ++i)
+			{
+				if (*reinterpret_cast<const uint8_t*>(a_funcBase + i) != 0xE8)
+					continue;
+
+				// Resolve relative CALL: target = (call_addr + 5) + int32_displacement
+				auto disp = *reinterpret_cast<const std::int32_t*>(a_funcBase + i + 1);
+				uintptr_t site = a_funcBase + i;
+				uintptr_t target = site + 5 + static_cast<std::intptr_t>(disp);
+
+				// Validate: target should be within ±1 GB of call site and above low memory.
+				// This filters out false positives where 0xE8 appears as part of an immediate
+				// operand in another instruction rather than as a CALL opcode.
+				auto diff = static_cast<std::intptr_t>(target - site);
+				if (target > 0x10000 && diff > -0x40000000LL && diff < 0x40000000LL)
+					a_outBuf[count++] = { site, target, i };
+			}
+		}
+		__except (1) {}
+
+		return count;
+	}
+}
+
+namespace Addictol
+{
+	// -----------------------------------------------------------------
+	// TOML configuration — per-file load time warning thresholds (ms)
+	// -----------------------------------------------------------------
+	static REX::TOML::F64<> fWarnThresholdMs{ "Profiler"sv, "fWarnThresholdMs"sv, 500.0 };
+	static REX::TOML::F64<> fCritThresholdMs{ "Profiler"sv, "fCritThresholdMs"sv, 2000.0 };
+
+	// -----------------------------------------------------------------
+	// Scanning parameters
+	// -----------------------------------------------------------------
+
+	// Maximum bytes to scan from CompileFiles entry point for CALL discovery.
+	// CompileFiles is typically 2000–4000 bytes; 4 KB is a safe upper bound.
+	static constexpr std::size_t kMaxScanBytes = 0x1000;
+
+	// Version-specific call-site indices within CompileFiles body.
+	// Each value selects the Nth E8 CALL instruction (0-based) found during scanning.
+	//
+	// To determine correct values for a new game version:
+	//   1. Set bProfiler=true in Addictol.toml
+	//   2. Launch the game and check Addictol.log for the "[Profiler/ESP]" call-site dump
+	//   3. Identify ConstructObjectList (2-param call in the file loop — sets RDX to TESFile*)
+	//      and InitAllForms (single-param call after the loop, one of the last calls)
+	//   4. Update the indices below and rebuild
+	//
+	// OG (1.10.163.0):
+	static constexpr std::size_t kOG_ConstructObjectListIdx = 5;
+	static constexpr std::size_t kOG_InitAllFormsIdx        = 12;
+	// NG (1.10.984+):
+	static constexpr std::size_t kNG_ConstructObjectListIdx = 5;
+	static constexpr std::size_t kNG_InitAllFormsIdx        = 12;
+
+	// REL::ID for TESDataHandler::CompileFiles
+	// OG (1.10.163): 57137  — prologue: PUSH RBX; PUSH RSI; PUSH RDI; PUSH R12-R15; SUB RSP
+	// NG (1.10.984+): 0     — prologue: MOV RAX,RSP (Detours handles instruction relocation)
+	//                         Set to actual NG ID once determined from address database.
+	//                         Set to 0 to disable NG profiling until the ID is known.
+	static constexpr std::uint32_t kCompileFilesID_OG = 57137;
+	static constexpr std::uint32_t kCompileFilesID_NG = 0;
+
+	// TESFile::filename — inline char[260] at this offset from TESFile*
+	static constexpr uintptr_t kTESFileNameOffset = 0x70;
+
+	// -----------------------------------------------------------------
+	// Call-site scanning
+	// -----------------------------------------------------------------
+
+	std::vector<ESPProfiler::CallSiteInfo> ESPProfiler::ScanCallSites(
+		uintptr_t a_funcBase, std::size_t a_maxBytes) noexcept
+	{
+		// Stack buffer sized for the maximum plausible number of CALLs in 4 KB of code.
+		// 256 * sizeof(CallSiteInfo) ≈ 6 KB — acceptable for a one-time init call.
+		static constexpr std::size_t kMaxResults = 256;
+		CallSiteInfo buffer[kMaxResults]{};
+
+		auto count = ScanCallSitesImpl(a_funcBase, a_maxBytes, buffer, kMaxResults);
+		return { buffer, buffer + count };
+	}
+
+	// -----------------------------------------------------------------
+	// TESFile filename extraction
+	// -----------------------------------------------------------------
+
+	const char* ESPProfiler::GetTESFileName(void* a_file) noexcept
+	{
+		if (!a_file)
+			return nullptr;
+
+		// No C++ objects here — __try is safe.
+		__try
+		{
+			auto addr = reinterpret_cast<uintptr_t>(a_file) + kTESFileNameOffset;
+			const char* name = reinterpret_cast<const char*>(addr);
+
+			// Sanity: first character must be printable ASCII
+			if (name[0] > 0x1F && name[0] < 0x7F)
+				return name;
+		}
+		__except (1)
+		{
+		}
+
+		return nullptr;
+	}
+
+	// -----------------------------------------------------------------
+	// Hook: TESDataHandler::CompileFiles
+	// Wraps the entire plugin compilation pass and records total time.
+	// -----------------------------------------------------------------
+
+	bool __fastcall ESPProfiler::HookCompileFiles(void* a_this) noexcept
+	{
+		auto* core = ProfilerCore::GetSingleton();
+
+		// Passthrough if profiler became inactive or original was not captured
+		if (!core->IsActive() || !OriginalCompileFiles)
+			return OriginalCompileFiles ? OriginalCompileFiles(a_this) : false;
+
+		// Reset the per-file counter for this compilation pass
+		GetSingleton()->m_currentFileIndex = 0;
+
+		core->MarkPhase("CompileFiles_Begin"sv);
+
+		double totalMs = 0.0;
+		bool result = false;
+		{
+			ScopedProfileTimer timer(totalMs);
+			result = OriginalCompileFiles(a_this);
+		}
+
+		core->SetTotalCompileTime(totalMs);
+		core->MarkPhase("CompileFiles_End"sv);
+
+		REX::INFO("[Profiler/ESP] CompileFiles completed in {:.1f} ms ({:.2f} s)"sv,
+			totalMs, totalMs / 1000.0);
+
+		return result;
+	}
+
+	// -----------------------------------------------------------------
+	// Hook: TESDataHandler::ConstructObjectList
+	// Times per-file record loading and feeds ESPProfileEntry to core.
+	// -----------------------------------------------------------------
+
+	void __fastcall ESPProfiler::HookConstructObjectList(void* a_this, void* a_file) noexcept
+	{
+		auto* core = ProfilerCore::GetSingleton();
+		auto* self = GetSingleton();
+
+		// Passthrough if profiler is inactive
+		if (!core->IsActive() || !OriginalConstructObjectList)
+		{
+			if (OriginalConstructObjectList)
+				OriginalConstructObjectList(a_this, a_file);
+			return;
+		}
+
+		ESPProfileEntry entry;
+		entry.loadOrderIndex = self->m_currentFileIndex++;
+
+		// Extract filename from TESFile* at offset +0x70 (SEH-protected)
+		const char* name = GetTESFileName(a_file);
+		entry.filename = name ? name : "(unknown)";
+
+		// Time the record construction phase (the heaviest per-file operation)
+		{
+			ScopedProfileTimer timer(entry.constructMs);
+			OriginalConstructObjectList(a_this, a_file);
+		}
+
+		entry.totalMs = entry.constructMs;
+
+		// Threshold-based warnings for slow-loading files
+		const double critMs = fCritThresholdMs.GetValue();
+		const double warnMs = fWarnThresholdMs.GetValue();
+
+		if (entry.constructMs >= critMs)
+		{
+			REX::WARN("[Profiler/ESP] CRITICAL: [{:3d}] {:40s} {:.1f} ms"sv,
+				entry.loadOrderIndex, entry.filename, entry.constructMs);
+		}
+		else if (entry.constructMs >= warnMs)
+		{
+			REX::WARN("[Profiler/ESP] SLOW: [{:3d}] {:40s} {:.1f} ms"sv,
+				entry.loadOrderIndex, entry.filename, entry.constructMs);
+		}
+
+		core->AddESPEntry(std::move(entry));
+	}
+
+	// -----------------------------------------------------------------
+	// Hook: TESDataHandler::InitAllForms
+	// Times the post-load form initialization pass.
+	// -----------------------------------------------------------------
+
+	void __fastcall ESPProfiler::HookInitAllForms(void* a_this) noexcept
+	{
+		auto* core = ProfilerCore::GetSingleton();
+
+		// Passthrough if profiler is inactive
+		if (!core->IsActive() || !OriginalInitAllForms)
+		{
+			if (OriginalInitAllForms)
+				OriginalInitAllForms(a_this);
+			return;
+		}
+
+		core->MarkPhase("InitAllForms_Begin"sv);
+
+		double ms = 0.0;
+		{
+			ScopedProfileTimer timer(ms);
+			OriginalInitAllForms(a_this);
+		}
+
+		core->SetInitAllFormsTime(ms);
+		core->MarkPhase("InitAllForms_End"sv);
+
+		REX::INFO("[Profiler/ESP] InitAllForms completed in {:.1f} ms ({:.2f} s)"sv,
+			ms, ms / 1000.0);
+	}
+
+	// -----------------------------------------------------------------
+	// Installation
+	// -----------------------------------------------------------------
+
+	void ESPProfiler::Install() noexcept
+	{
+		if (m_installed)
+			return;
+
+		if (!ProfilerCore::GetSingleton()->IsActive())
+		{
+			REX::INFO("[Profiler/ESP] Profiler not active, skipping ESP hooks"sv);
+			return;
+		}
+
+		REX::INFO("[Profiler/ESP] Installing ESP/ESM load profiler hooks..."sv);
+
+		// ---- Step 1: Locate CompileFiles via address library ----
+
+		const bool isOG = RELEX::IsRuntimeOG();
+		const std::uint32_t compileFilesID = isOG ? kCompileFilesID_OG : kCompileFilesID_NG;
+
+		if (compileFilesID == 0)
+		{
+			REX::WARN("[Profiler/ESP] CompileFiles ID not configured for {} runtime, "
+				"ESP profiling disabled"sv, isOG ? "OG" : "NG");
+			return;
+		}
+
+		uintptr_t compileFilesAddr = SafeResolveID(compileFilesID);
+		if (!compileFilesAddr)
+		{
+			REX::ERROR("[Profiler/ESP] Failed to resolve CompileFiles (REL::ID {})"sv,
+				compileFilesID);
+			return;
+		}
+
+		REX::INFO("[Profiler/ESP] CompileFiles at {:016X} (REL::ID {}, {})"sv,
+			compileFilesAddr, compileFilesID, isOG ? "OG" : "NG");
+
+		// ---- Step 2: Hook CompileFiles ----
+		// OG: standard prologue (PUSH regs; SUB RSP) — DetourJump patches entry point.
+		// NG: MOV RAX,RSP prologue — Detours handles instruction relocation to trampoline.
+
+		*(uintptr_t*)(&OriginalCompileFiles) =
+			RELEX::DetourJump(compileFilesAddr, (uintptr_t)&HookCompileFiles);
+
+		if (!OriginalCompileFiles)
+		{
+			REX::ERROR("[Profiler/ESP] Failed to detour CompileFiles"sv);
+			return;
+		}
+
+		REX::INFO("[Profiler/ESP] CompileFiles hooked (trampoline: {:016X})"sv,
+			reinterpret_cast<uintptr_t>(OriginalCompileFiles));
+
+		// ---- Step 3: Scan CompileFiles body for internal CALL sites ----
+		// The sub-functions ConstructObjectList and InitAllForms have no address library
+		// IDs, so we locate them by scanning CompileFiles for E8 (near CALL) instructions
+		// and selecting version-specific indices.
+
+		auto callSites = ScanCallSites(compileFilesAddr, kMaxScanBytes);
+
+		REX::INFO("[Profiler/ESP] Found {} call sites in CompileFiles (scan: {} bytes):"sv,
+			callSites.size(), kMaxScanBytes);
+
+		for (std::size_t i = 0; i < callSites.size(); ++i)
+		{
+			REX::INFO("[Profiler/ESP]   [{:2d}] site={:016X} target={:016X} (offset +0x{:04X})"sv,
+				i, callSites[i].site, callSites[i].target, callSites[i].offset);
+		}
+
+		// ---- Step 4: Hook ConstructObjectList (call-site patch) ----
+		// This is a 2-param call (this, TESFile*) inside CompileFiles' per-file loop.
+		// Patching the call-site rather than the function entry avoids prologue concerns
+		// and precisely targets calls originating from CompileFiles.
+
+		const std::size_t constructIdx = isOG
+			? kOG_ConstructObjectListIdx : kNG_ConstructObjectListIdx;
+
+		if (constructIdx < callSites.size())
+		{
+			const auto& cs = callSites[constructIdx];
+
+			*(uintptr_t*)(&OriginalConstructObjectList) =
+				RELEX::DetourCall(cs.site, (uintptr_t)&HookConstructObjectList);
+
+			if (OriginalConstructObjectList)
+			{
+				REX::INFO("[Profiler/ESP] ConstructObjectList hooked "
+					"(site: {:016X}, target: {:016X}, index: {})"sv,
+					cs.site, cs.target, constructIdx);
+			}
+			else
+			{
+				REX::WARN("[Profiler/ESP] DetourCall failed for ConstructObjectList "
+					"at site {:016X}"sv, cs.site);
+			}
+		}
+		else
+		{
+			REX::WARN("[Profiler/ESP] ConstructObjectList call index {} out of range "
+				"(found {} calls). Review call-site dump above."sv,
+				constructIdx, callSites.size());
+		}
+
+		// ---- Step 5: Hook InitAllForms (call-site patch) ----
+		// This is a single-param call (this only) after the file loop in CompileFiles.
+		// Resolves cross-references and finalizes all loaded forms.
+
+		const std::size_t initFormsIdx = isOG
+			? kOG_InitAllFormsIdx : kNG_InitAllFormsIdx;
+
+		if (initFormsIdx < callSites.size())
+		{
+			const auto& cs = callSites[initFormsIdx];
+
+			*(uintptr_t*)(&OriginalInitAllForms) =
+				RELEX::DetourCall(cs.site, (uintptr_t)&HookInitAllForms);
+
+			if (OriginalInitAllForms)
+			{
+				REX::INFO("[Profiler/ESP] InitAllForms hooked "
+					"(site: {:016X}, target: {:016X}, index: {})"sv,
+					cs.site, cs.target, initFormsIdx);
+			}
+			else
+			{
+				REX::WARN("[Profiler/ESP] DetourCall failed for InitAllForms "
+					"at site {:016X}"sv, cs.site);
+			}
+		}
+		else
+		{
+			REX::WARN("[Profiler/ESP] InitAllForms call index {} out of range "
+				"(found {} calls). Review call-site dump above."sv,
+				initFormsIdx, callSites.size());
+		}
+
+		// ---- Done ----
+
+		m_installed = (OriginalCompileFiles != nullptr);
+
+		REX::INFO("[Profiler/ESP] Installation {} "
+			"(CompileFiles: {}, ConstructObjectList: {}, InitAllForms: {})"sv,
+			m_installed ? "complete" : "FAILED",
+			OriginalCompileFiles ? "OK" : "FAIL",
+			OriginalConstructObjectList ? "OK" : "SKIP",
+			OriginalInitAllForms ? "OK" : "SKIP");
+	}
+}

--- a/Addictol/Source/AdProfilerESP.cpp
+++ b/Addictol/Source/AdProfilerESP.cpp
@@ -2,6 +2,14 @@
 #include <AdProfilerCore.h>
 #include <AdUtils.h>
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#ifdef ERROR
+#undef ERROR
+#endif
+
 namespace
 {
 	using namespace Addictol;
@@ -44,11 +52,12 @@ namespace
 
 	// Calls the original ConstructObjectList trampoline under SEH protection.
 	// Returns false if an exception was caught.
-	bool SafeCallConstructObjectList(void(__fastcall* a_original)(void*, void*), void* a_this, void* a_file) noexcept
+	bool SafeCallConstructObjectList(void(__fastcall* a_original)(void*, void*, bool, void*),
+		void* a_this, void* a_file, bool a_isFirst, void* a_param4) noexcept
 	{
 		__try
 		{
-			a_original(a_this, a_file);
+			a_original(a_this, a_file, a_isFirst, a_param4);
 			return true;
 		}
 		__except (1)
@@ -116,29 +125,21 @@ namespace Addictol
 	static REX::TOML::Bool<> bESPSubHooks{ "Profiler"sv, "bESPSubHooks"sv, false };
 
 	// -----------------------------------------------------------------
-	// Scanning parameters
+	// Known function RVAs
 	// -----------------------------------------------------------------
-
-	// Maximum bytes to scan from CompileFiles entry point for CALL discovery.
-	// CompileFiles is typically 2000–4000 bytes; 4 KB is a safe upper bound.
-	static constexpr std::size_t kMaxScanBytes = 0x1000;
-
-	// Version-specific call-site indices within CompileFiles body.
-	// Each value selects the Nth E8 CALL instruction (0-based) found during scanning.
+	// These are offsets from the Fallout4.exe module base, confirmed by
+	// Ghidra decompilation and the F4LoadTimeProfiler project.
 	//
-	// To determine correct values for a new game version:
-	//   1. Set bProfiler=true in Addictol.toml
-	//   2. Launch the game and check Addictol.log for the "[Profiler/ESP]" call-site dump
-	//   3. Identify ConstructObjectList (2-param call in the file loop — sets RDX to TESFile*)
-	//      and InitAllForms (single-param call after the loop, one of the last calls)
-	//   4. Update the indices below and rebuild
-	//
-	// OG (1.10.163.0):
-	static constexpr std::size_t kOG_ConstructObjectListIdx = 5;
-	static constexpr std::size_t kOG_InitAllFormsIdx        = 12;
-	// NG (1.10.984+):
-	static constexpr std::size_t kNG_ConstructObjectListIdx = 5;
-	static constexpr std::size_t kNG_InitAllFormsIdx        = 12;
+	// OG (1.10.163):
+	//   ConstructObjectList: 0x118750 (4 params: this, TESFile*, bool, void*)
+	//   InitAllForms:        0x11B070 (1 param: this)
+	// NG (1.11.191):
+	//   ConstructObjectList: 0x2DFA40 (4 params)
+	//   InitAllForms:        not yet determined
+	static constexpr uintptr_t kOG_ConstructObjectList_RVA = 0x118750;
+	static constexpr uintptr_t kOG_InitAllForms_RVA        = 0x11B070;
+	static constexpr uintptr_t kNG_ConstructObjectList_RVA  = 0x2DFA40;
+	static constexpr uintptr_t kNG_InitAllForms_RVA         = 0; // disabled until known
 
 	// REL::ID for TESDataHandler::CompileFiles
 	// OG (1.10.163): 57137  — prologue: PUSH RBX; PUSH RSI; PUSH RDI; PUSH R12-R15; SUB RSP
@@ -241,7 +242,7 @@ namespace Addictol
 	// Times per-file record loading and feeds ESPProfileEntry to core.
 	// -----------------------------------------------------------------
 
-	void __fastcall ESPProfiler::HookConstructObjectList(void* a_this, void* a_file) noexcept
+	void __fastcall ESPProfiler::HookConstructObjectList(void* a_this, void* a_file, bool a_isFirst, void* a_param4) noexcept
 	{
 		auto* core = ProfilerCore::GetSingleton();
 		auto* self = GetSingleton();
@@ -250,7 +251,7 @@ namespace Addictol
 		if (!core->IsActive() || !OriginalConstructObjectList)
 		{
 			if (OriginalConstructObjectList)
-				OriginalConstructObjectList(a_this, a_file);
+				OriginalConstructObjectList(a_this, a_file, a_isFirst, a_param4);
 			return;
 		}
 
@@ -263,7 +264,7 @@ namespace Addictol
 
 		// Time the record construction phase (the heaviest per-file operation)
 		auto start = std::chrono::high_resolution_clock::now();
-		bool ok = SafeCallConstructObjectList(OriginalConstructObjectList, a_this, a_file);
+		bool ok = SafeCallConstructObjectList(OriginalConstructObjectList, a_this, a_file, a_isFirst, a_param4);
 		auto end = std::chrono::high_resolution_clock::now();
 		entry.constructMs = std::chrono::duration<double, std::milli>(end - start).count();
 
@@ -387,14 +388,14 @@ namespace Addictol
 		REX::INFO("[Profiler/ESP] CompileFiles hooked (trampoline: {:016X})"sv,
 			reinterpret_cast<uintptr_t>(OriginalCompileFiles));
 
-		// ---- Step 3: Scan CompileFiles body for internal CALL sites ----
-		// The sub-functions ConstructObjectList and InitAllForms have no address library
-		// IDs, so we locate them by scanning CompileFiles for E8 (near CALL) instructions
-		// and selecting version-specific indices.
+		// ---- Step 3: Diagnostic call-site scan (informational only) ----
+		// Dumps all E8 CALL sites in CompileFiles for version identification.
+		// Not used for hooking — kept for diagnosing new game versions.
 
+		static constexpr std::size_t kMaxScanBytes = 0x1000;
 		auto callSites = ScanCallSites(compileFilesAddr, kMaxScanBytes);
 
-		REX::INFO("[Profiler/ESP] Found {} call sites in CompileFiles (scan: {} bytes):"sv,
+		REX::INFO("[Profiler/ESP] Diagnostic: {} call sites in CompileFiles ({} bytes):"sv,
 			callSites.size(), kMaxScanBytes);
 
 		for (std::size_t i = 0; i < callSites.size(); ++i)
@@ -403,83 +404,97 @@ namespace Addictol
 				i, callSites[i].site, callSites[i].target, callSites[i].offset);
 		}
 
-		// ---- Step 4: Hook ConstructObjectList (call-site patch) ----
-		// This is a 2-param call (this, TESFile*) inside CompileFiles' per-file loop.
-		// Patching the call-site rather than the function entry avoids prologue concerns
-		// and precisely targets calls originating from CompileFiles.
-		//
-		// CAUTION: bESPSubHooks must be true to enable these hooks.
-		// The call-site indices are version-specific and must be verified via the
-		// call-site dump before enabling. Wrong indices = wrong function signatures = CTD.
+		// ---- Step 4: Hook ConstructObjectList + InitAllForms via known RVAs ----
+		// These functions have no address library IDs. We resolve them using
+		// hardcoded RVAs confirmed by Ghidra analysis and F4LoadTimeProfiler.
+		// Uses DetourJump (inline hook at function entry), NOT call-site patching.
 
 		if (!bESPSubHooks.GetValue())
 		{
 			REX::INFO("[Profiler/ESP] Sub-hooks disabled (bESPSubHooks=false). "
-				"Only CompileFiles timing active. Review call-site dump above to "
-				"determine correct indices, then enable bESPSubHooks."sv);
+				"Only CompileFiles timing active."sv);
 		}
 		else
 		{
-			const std::size_t constructIdx = isOG
-				? kOG_ConstructObjectListIdx : kNG_ConstructObjectListIdx;
-
-			if (constructIdx < callSites.size())
+			HMODULE hGame = GetModuleHandleA("Fallout4.exe");
+			if (!hGame)
 			{
-				const auto& cs = callSites[constructIdx];
-
-				*(uintptr_t*)(&OriginalConstructObjectList) =
-					RELEX::DetourCall(cs.site, (uintptr_t)&HookConstructObjectList);
-
-				if (OriginalConstructObjectList)
-				{
-					REX::INFO("[Profiler/ESP] ConstructObjectList hooked "
-						"(site: {:016X}, target: {:016X}, index: {})"sv,
-						cs.site, cs.target, constructIdx);
-				}
-				else
-				{
-					REX::WARN("[Profiler/ESP] DetourCall failed for ConstructObjectList "
-						"at site {:016X}"sv, cs.site);
-				}
+				REX::WARN("[Profiler/ESP] Cannot find Fallout4.exe module, "
+					"sub-hooks unavailable"sv);
 			}
 			else
 			{
-				REX::WARN("[Profiler/ESP] ConstructObjectList call index {} out of range "
-					"(found {} calls). Review call-site dump above."sv,
-					constructIdx, callSites.size());
-			}
+				uintptr_t moduleBase = reinterpret_cast<uintptr_t>(hGame);
+				REX::INFO("[Profiler/ESP] Fallout4.exe base: {:016X}"sv, moduleBase);
 
-			// ---- Step 5: Hook InitAllForms (call-site patch) ----
-			// This is a single-param call (this only) after the file loop in CompileFiles.
-			// Resolves cross-references and finalizes all loaded forms.
+				// ---- ConstructObjectList (4 params: this, TESFile*, bool, void*) ----
+				const uintptr_t constructRVA = isOG
+					? kOG_ConstructObjectList_RVA : kNG_ConstructObjectList_RVA;
 
-			const std::size_t initFormsIdx = isOG
-				? kOG_InitAllFormsIdx : kNG_InitAllFormsIdx;
-
-			if (initFormsIdx < callSites.size())
-			{
-				const auto& cs = callSites[initFormsIdx];
-
-				*(uintptr_t*)(&OriginalInitAllForms) =
-					RELEX::DetourCall(cs.site, (uintptr_t)&HookInitAllForms);
-
-				if (OriginalInitAllForms)
+				if (constructRVA != 0)
 				{
-					REX::INFO("[Profiler/ESP] InitAllForms hooked "
-						"(site: {:016X}, target: {:016X}, index: {})"sv,
-						cs.site, cs.target, initFormsIdx);
+					uintptr_t constructAddr = moduleBase + constructRVA;
+
+					// Log prologue bytes for verification
+					auto* p = reinterpret_cast<const uint8_t*>(constructAddr);
+					REX::INFO("[Profiler/ESP] ConstructObjectList at {:016X} (RVA {:06X}), "
+						"prologue: {:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X}"sv,
+						constructAddr, constructRVA,
+						p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+
+					*(uintptr_t*)(&OriginalConstructObjectList) =
+						RELEX::DetourJump(constructAddr, (uintptr_t)&HookConstructObjectList);
+
+					if (OriginalConstructObjectList)
+					{
+						REX::INFO("[Profiler/ESP] ConstructObjectList hooked "
+							"(trampoline: {:016X})"sv,
+							reinterpret_cast<uintptr_t>(OriginalConstructObjectList));
+					}
+					else
+					{
+						REX::WARN("[Profiler/ESP] Failed to hook ConstructObjectList"sv);
+					}
 				}
 				else
 				{
-					REX::WARN("[Profiler/ESP] DetourCall failed for InitAllForms "
-						"at site {:016X}"sv, cs.site);
+					REX::INFO("[Profiler/ESP] ConstructObjectList RVA not configured for "
+						"{} runtime"sv, isOG ? "OG" : "NG");
 				}
-			}
-			else
-			{
-				REX::WARN("[Profiler/ESP] InitAllForms call index {} out of range "
-					"(found {} calls). Review call-site dump above."sv,
-					initFormsIdx, callSites.size());
+
+				// ---- InitAllForms (1 param: this) ----
+				const uintptr_t initRVA = isOG
+					? kOG_InitAllForms_RVA : kNG_InitAllForms_RVA;
+
+				if (initRVA != 0)
+				{
+					uintptr_t initAddr = moduleBase + initRVA;
+
+					auto* p = reinterpret_cast<const uint8_t*>(initAddr);
+					REX::INFO("[Profiler/ESP] InitAllForms at {:016X} (RVA {:06X}), "
+						"prologue: {:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X}"sv,
+						initAddr, initRVA,
+						p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+
+					*(uintptr_t*)(&OriginalInitAllForms) =
+						RELEX::DetourJump(initAddr, (uintptr_t)&HookInitAllForms);
+
+					if (OriginalInitAllForms)
+					{
+						REX::INFO("[Profiler/ESP] InitAllForms hooked "
+							"(trampoline: {:016X})"sv,
+							reinterpret_cast<uintptr_t>(OriginalInitAllForms));
+					}
+					else
+					{
+						REX::WARN("[Profiler/ESP] Failed to hook InitAllForms"sv);
+					}
+				}
+				else
+				{
+					REX::INFO("[Profiler/ESP] InitAllForms RVA not configured for "
+						"{} runtime"sv, isOG ? "OG" : "NG");
+				}
 			}
 		}
 

--- a/Addictol/Source/AdProfilerESP.cpp
+++ b/Addictol/Source/AdProfilerESP.cpp
@@ -131,23 +131,21 @@ namespace Addictol
 	// Ghidra decompilation and the F4LoadTimeProfiler project.
 	//
 	// OG (1.10.163):
+	//   CompileFiles:        REL::ID 57137 (0x116C20)
 	//   ConstructObjectList: 0x118750 (4 params: this, TESFile*, bool, void*)
 	//   InitAllForms:        0x11B070 (1 param: this)
 	// NG (1.11.191):
+	//   CompileFiles:        0x2E6C50 (MOV RAX,RSP prologue)
 	//   ConstructObjectList: 0x2DFA40 (4 params)
 	//   InitAllForms:        not yet determined
 	static constexpr uintptr_t kOG_ConstructObjectList_RVA = 0x118750;
 	static constexpr uintptr_t kOG_InitAllForms_RVA        = 0x11B070;
+	static constexpr uintptr_t kNG_CompileFiles_RVA         = 0x2E6C50;
 	static constexpr uintptr_t kNG_ConstructObjectList_RVA  = 0x2DFA40;
 	static constexpr uintptr_t kNG_InitAllForms_RVA         = 0; // disabled until known
 
-	// REL::ID for TESDataHandler::CompileFiles
-	// OG (1.10.163): 57137  — prologue: PUSH RBX; PUSH RSI; PUSH RDI; PUSH R12-R15; SUB RSP
-	// NG (1.10.984+): 0     — prologue: MOV RAX,RSP (Detours handles instruction relocation)
-	//                         Set to actual NG ID once determined from address database.
-	//                         Set to 0 to disable NG profiling until the ID is known.
+	// REL::ID for TESDataHandler::CompileFiles (OG only; NG uses direct RVA)
 	static constexpr std::uint32_t kCompileFilesID_OG = 57137;
-	static constexpr std::uint32_t kCompileFilesID_NG = 0;
 
 	// TESFile::filename — inline char[260] at this offset from TESFile*
 	static constexpr uintptr_t kTESFileNameOffset = 0x70;
@@ -349,28 +347,58 @@ namespace Addictol
 
 		REX::INFO("[Profiler/ESP] Installing ESP/ESM load profiler hooks..."sv);
 
-		// ---- Step 1: Locate CompileFiles via address library ----
+		// ---- Step 1: Locate CompileFiles ----
 
 		const bool isOG = RELEX::IsRuntimeOG();
-		const std::uint32_t compileFilesID = isOG ? kCompileFilesID_OG : kCompileFilesID_NG;
+		uintptr_t compileFilesAddr = 0;
 
-		if (compileFilesID == 0)
+		if (isOG)
 		{
-			REX::WARN("[Profiler/ESP] CompileFiles ID not configured for {} runtime, "
-				"ESP profiling disabled"sv, isOG ? "OG" : "NG");
-			return;
+			// OG: Resolve via address library (REL::ID)
+			compileFilesAddr = SafeResolveID(kCompileFilesID_OG);
+			if (!compileFilesAddr)
+			{
+				REX::ERROR("[Profiler/ESP] Failed to resolve CompileFiles (REL::ID {})"sv,
+					kCompileFilesID_OG);
+				return;
+			}
+			REX::INFO("[Profiler/ESP] CompileFiles at {:016X} (REL::ID {}, OG)"sv,
+				compileFilesAddr, kCompileFilesID_OG);
 		}
-
-		uintptr_t compileFilesAddr = SafeResolveID(compileFilesID);
-		if (!compileFilesAddr)
+		else
 		{
-			REX::ERROR("[Profiler/ESP] Failed to resolve CompileFiles (REL::ID {})"sv,
-				compileFilesID);
-			return;
-		}
+			// NG: Resolve via known RVA from module base
+			if (kNG_CompileFiles_RVA == 0)
+			{
+				REX::WARN("[Profiler/ESP] CompileFiles RVA not configured for NG, "
+					"ESP profiling disabled"sv);
+				return;
+			}
 
-		REX::INFO("[Profiler/ESP] CompileFiles at {:016X} (REL::ID {}, {})"sv,
-			compileFilesAddr, compileFilesID, isOG ? "OG" : "NG");
+			HMODULE hGame = GetModuleHandleA("Fallout4.exe");
+			if (!hGame)
+			{
+				REX::WARN("[Profiler/ESP] Cannot find Fallout4.exe module"sv);
+				return;
+			}
+
+			compileFilesAddr = reinterpret_cast<uintptr_t>(hGame) + kNG_CompileFiles_RVA;
+
+			// Verify NG prologue: MOV RAX,RSP (48 8B C4)
+			auto* p = reinterpret_cast<const uint8_t*>(compileFilesAddr);
+			REX::INFO("[Profiler/ESP] CompileFiles at {:016X} (RVA {:06X}, NG), "
+				"prologue: {:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X}"sv,
+				compileFilesAddr, kNG_CompileFiles_RVA,
+				p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+
+			if (p[0] != 0x48 || p[1] != 0x8B || p[2] != 0xC4)
+			{
+				REX::WARN("[Profiler/ESP] CompileFiles prologue mismatch! "
+					"Expected 48 8B C4 (MOV RAX,RSP). NG RVA may be wrong for this version. "
+					"ESP profiling disabled."sv);
+				return;
+			}
+		}
 
 		// ---- Step 2: Hook CompileFiles ----
 		// OG: standard prologue (PUSH regs; SUB RSP) — DetourJump patches entry point.

--- a/Addictol/Source/AdProfilerESP.cpp
+++ b/Addictol/Source/AdProfilerESP.cpp
@@ -66,10 +66,11 @@ namespace
 namespace Addictol
 {
 	// -----------------------------------------------------------------
-	// TOML configuration — per-file load time warning thresholds (ms)
+	// TOML configuration
 	// -----------------------------------------------------------------
 	static REX::TOML::F64<> fWarnThresholdMs{ "Profiler"sv, "fWarnThresholdMs"sv, 500.0 };
 	static REX::TOML::F64<> fCritThresholdMs{ "Profiler"sv, "fCritThresholdMs"sv, 2000.0 };
+	static REX::TOML::Bool<> bESPSubHooks{ "Profiler"sv, "bESPSubHooks"sv, false };
 
 	// -----------------------------------------------------------------
 	// Scanning parameters
@@ -342,67 +343,80 @@ namespace Addictol
 		// This is a 2-param call (this, TESFile*) inside CompileFiles' per-file loop.
 		// Patching the call-site rather than the function entry avoids prologue concerns
 		// and precisely targets calls originating from CompileFiles.
+		//
+		// CAUTION: bESPSubHooks must be true to enable these hooks.
+		// The call-site indices are version-specific and must be verified via the
+		// call-site dump before enabling. Wrong indices = wrong function signatures = CTD.
 
-		const std::size_t constructIdx = isOG
-			? kOG_ConstructObjectListIdx : kNG_ConstructObjectListIdx;
-
-		if (constructIdx < callSites.size())
+		if (!bESPSubHooks.GetValue())
 		{
-			const auto& cs = callSites[constructIdx];
-
-			*(uintptr_t*)(&OriginalConstructObjectList) =
-				RELEX::DetourCall(cs.site, (uintptr_t)&HookConstructObjectList);
-
-			if (OriginalConstructObjectList)
-			{
-				REX::INFO("[Profiler/ESP] ConstructObjectList hooked "
-					"(site: {:016X}, target: {:016X}, index: {})"sv,
-					cs.site, cs.target, constructIdx);
-			}
-			else
-			{
-				REX::WARN("[Profiler/ESP] DetourCall failed for ConstructObjectList "
-					"at site {:016X}"sv, cs.site);
-			}
+			REX::INFO("[Profiler/ESP] Sub-hooks disabled (bESPSubHooks=false). "
+				"Only CompileFiles timing active. Review call-site dump above to "
+				"determine correct indices, then enable bESPSubHooks."sv);
 		}
 		else
 		{
-			REX::WARN("[Profiler/ESP] ConstructObjectList call index {} out of range "
-				"(found {} calls). Review call-site dump above."sv,
-				constructIdx, callSites.size());
-		}
+			const std::size_t constructIdx = isOG
+				? kOG_ConstructObjectListIdx : kNG_ConstructObjectListIdx;
 
-		// ---- Step 5: Hook InitAllForms (call-site patch) ----
-		// This is a single-param call (this only) after the file loop in CompileFiles.
-		// Resolves cross-references and finalizes all loaded forms.
-
-		const std::size_t initFormsIdx = isOG
-			? kOG_InitAllFormsIdx : kNG_InitAllFormsIdx;
-
-		if (initFormsIdx < callSites.size())
-		{
-			const auto& cs = callSites[initFormsIdx];
-
-			*(uintptr_t*)(&OriginalInitAllForms) =
-				RELEX::DetourCall(cs.site, (uintptr_t)&HookInitAllForms);
-
-			if (OriginalInitAllForms)
+			if (constructIdx < callSites.size())
 			{
-				REX::INFO("[Profiler/ESP] InitAllForms hooked "
-					"(site: {:016X}, target: {:016X}, index: {})"sv,
-					cs.site, cs.target, initFormsIdx);
+				const auto& cs = callSites[constructIdx];
+
+				*(uintptr_t*)(&OriginalConstructObjectList) =
+					RELEX::DetourCall(cs.site, (uintptr_t)&HookConstructObjectList);
+
+				if (OriginalConstructObjectList)
+				{
+					REX::INFO("[Profiler/ESP] ConstructObjectList hooked "
+						"(site: {:016X}, target: {:016X}, index: {})"sv,
+						cs.site, cs.target, constructIdx);
+				}
+				else
+				{
+					REX::WARN("[Profiler/ESP] DetourCall failed for ConstructObjectList "
+						"at site {:016X}"sv, cs.site);
+				}
 			}
 			else
 			{
-				REX::WARN("[Profiler/ESP] DetourCall failed for InitAllForms "
-					"at site {:016X}"sv, cs.site);
+				REX::WARN("[Profiler/ESP] ConstructObjectList call index {} out of range "
+					"(found {} calls). Review call-site dump above."sv,
+					constructIdx, callSites.size());
 			}
-		}
-		else
-		{
-			REX::WARN("[Profiler/ESP] InitAllForms call index {} out of range "
-				"(found {} calls). Review call-site dump above."sv,
-				initFormsIdx, callSites.size());
+
+			// ---- Step 5: Hook InitAllForms (call-site patch) ----
+			// This is a single-param call (this only) after the file loop in CompileFiles.
+			// Resolves cross-references and finalizes all loaded forms.
+
+			const std::size_t initFormsIdx = isOG
+				? kOG_InitAllFormsIdx : kNG_InitAllFormsIdx;
+
+			if (initFormsIdx < callSites.size())
+			{
+				const auto& cs = callSites[initFormsIdx];
+
+				*(uintptr_t*)(&OriginalInitAllForms) =
+					RELEX::DetourCall(cs.site, (uintptr_t)&HookInitAllForms);
+
+				if (OriginalInitAllForms)
+				{
+					REX::INFO("[Profiler/ESP] InitAllForms hooked "
+						"(site: {:016X}, target: {:016X}, index: {})"sv,
+						cs.site, cs.target, initFormsIdx);
+				}
+				else
+				{
+					REX::WARN("[Profiler/ESP] DetourCall failed for InitAllForms "
+						"at site {:016X}"sv, cs.site);
+				}
+			}
+			else
+			{
+				REX::WARN("[Profiler/ESP] InitAllForms call index {} out of range "
+					"(found {} calls). Review call-site dump above."sv,
+					initFormsIdx, callSites.size());
+			}
 		}
 
 		// ---- Done ----

--- a/Addictol/Source/AdProfilerESP.cpp
+++ b/Addictol/Source/AdProfilerESP.cpp
@@ -28,6 +28,49 @@ namespace
 		return result;
 	}
 
+	// Calls the original CompileFiles trampoline under SEH protection.
+	// Returns: 0 = exception caught, 1 = original returned true, 2 = original returned false
+	int SafeCallCompileFiles(bool(__fastcall* a_original)(void*), void* a_this) noexcept
+	{
+		__try
+		{
+			return a_original(a_this) ? 1 : 2;
+		}
+		__except (1)
+		{
+			return 0;
+		}
+	}
+
+	// Calls the original ConstructObjectList trampoline under SEH protection.
+	// Returns false if an exception was caught.
+	bool SafeCallConstructObjectList(void(__fastcall* a_original)(void*, void*), void* a_this, void* a_file) noexcept
+	{
+		__try
+		{
+			a_original(a_this, a_file);
+			return true;
+		}
+		__except (1)
+		{
+			return false;
+		}
+	}
+
+	// Calls the original InitAllForms trampoline under SEH protection.
+	bool SafeCallInitAllForms(void(__fastcall* a_original)(void*), void* a_this) noexcept
+	{
+		__try
+		{
+			a_original(a_this);
+			return true;
+		}
+		__except (1)
+		{
+			return false;
+		}
+	}
+
 	// Scans memory starting at a_funcBase for E8 (near relative CALL) instructions.
 	// Writes resolved CallSiteInfo entries into a_outBuf (up to a_maxResults).
 	// Returns the number of valid call sites found.
@@ -163,18 +206,27 @@ namespace Addictol
 		if (!core->IsActive() || !OriginalCompileFiles)
 			return OriginalCompileFiles ? OriginalCompileFiles(a_this) : false;
 
+		REX::INFO("[Profiler/ESP] CompileFiles entered (this={:016X})"sv,
+			reinterpret_cast<uintptr_t>(a_this));
+
 		// Reset the per-file counter for this compilation pass
 		GetSingleton()->m_currentFileIndex = 0;
 
 		core->MarkPhase("CompileFiles_Begin"sv);
 
-		double totalMs = 0.0;
-		bool result = false;
+		auto start = std::chrono::high_resolution_clock::now();
+		int callResult = SafeCallCompileFiles(OriginalCompileFiles, a_this);
+		auto end = std::chrono::high_resolution_clock::now();
+		double totalMs = std::chrono::duration<double, std::milli>(end - start).count();
+
+		if (callResult == 0)
 		{
-			ScopedProfileTimer timer(totalMs);
-			result = OriginalCompileFiles(a_this);
+			REX::ERROR("[Profiler/ESP] CompileFiles CRASHED in original function! "
+				"SEH caught the exception. Returning false."sv);
+			return false;
 		}
 
+		bool result = (callResult == 1);
 		core->SetTotalCompileTime(totalMs);
 		core->MarkPhase("CompileFiles_End"sv);
 
@@ -210,9 +262,16 @@ namespace Addictol
 		entry.filename = name ? name : "(unknown)";
 
 		// Time the record construction phase (the heaviest per-file operation)
+		auto start = std::chrono::high_resolution_clock::now();
+		bool ok = SafeCallConstructObjectList(OriginalConstructObjectList, a_this, a_file);
+		auto end = std::chrono::high_resolution_clock::now();
+		entry.constructMs = std::chrono::duration<double, std::milli>(end - start).count();
+
+		if (!ok)
 		{
-			ScopedProfileTimer timer(entry.constructMs);
-			OriginalConstructObjectList(a_this, a_file);
+			REX::ERROR("[Profiler/ESP] ConstructObjectList CRASHED on file [{}] {}!"sv,
+				entry.loadOrderIndex, entry.filename);
+			return;
 		}
 
 		entry.totalMs = entry.constructMs;
@@ -254,10 +313,15 @@ namespace Addictol
 
 		core->MarkPhase("InitAllForms_Begin"sv);
 
-		double ms = 0.0;
+		auto start = std::chrono::high_resolution_clock::now();
+		bool ok = SafeCallInitAllForms(OriginalInitAllForms, a_this);
+		auto end = std::chrono::high_resolution_clock::now();
+		double ms = std::chrono::duration<double, std::milli>(end - start).count();
+
+		if (!ok)
 		{
-			ScopedProfileTimer timer(ms);
-			OriginalInitAllForms(a_this);
+			REX::ERROR("[Profiler/ESP] InitAllForms CRASHED! SEH caught the exception."sv);
+			return;
 		}
 
 		core->SetInitAllFormsTime(ms);

--- a/Addictol/Source/AdProfilerESP.cpp
+++ b/Addictol/Source/AdProfilerESP.cpp
@@ -416,9 +416,10 @@ namespace Addictol
 		REX::INFO("[Profiler/ESP] CompileFiles hooked (trampoline: {:016X})"sv,
 			reinterpret_cast<uintptr_t>(OriginalCompileFiles));
 
-		// ---- Step 3: Diagnostic call-site scan (informational only) ----
+		// ---- Step 3: Diagnostic call-site scan ----
 		// Dumps all E8 CALL sites in CompileFiles for version identification.
-		// Not used for hooking — kept for diagnosing new game versions.
+		// This is informational only — hooking uses direct RVA + DetourJump,
+		// NOT call-site patching. Useful for identifying functions in new builds.
 
 		static constexpr std::size_t kMaxScanBytes = 0x1000;
 		auto callSites = ScanCallSites(compileFilesAddr, kMaxScanBytes);

--- a/Addictol/Source/AdProfilerESP.cpp
+++ b/Addictol/Source/AdProfilerESP.cpp
@@ -128,21 +128,44 @@ namespace Addictol
 	// Known function RVAs
 	// -----------------------------------------------------------------
 	// These are offsets from the Fallout4.exe module base, confirmed by
-	// Ghidra decompilation and the F4LoadTimeProfiler project.
+	// Ghidra decompilation, F4LoadTimeProfiler, and NG PDB analysis.
 	//
 	// OG (1.10.163):
-	//   CompileFiles:        REL::ID 57137 (0x116C20)
-	//   ConstructObjectList: 0x118750 (4 params: this, TESFile*, bool, void*)
-	//   InitAllForms:        0x11B070 (1 param: this)
-	// NG (1.11.191):
-	//   CompileFiles:        0x2E6C50 (MOV RAX,RSP prologue)
-	//   ConstructObjectList: 0x2DFA40 (4 params)
-	//   InitAllForms:        not yet determined
+	//   CompileFiles:        REL::ID 57137 (0x116C20, 1153 bytes)
+	//   ConstructObjectList: 0x118750 (594 bytes, 4 params: this, TESFile*, bool, void*)
+	//   InitAllForms:        0x11B070 (2116 bytes, 1 param: this)
+	//
+	// NG (1.11.191) — extracted from Fallout41.11.191.0.pdb public symbols:
+	//   CompileFiles:        0x2E6C50 (NOT in PDB publics; confirmed by prologue 48 8B C4)
+	//   ConstructObjectList: 0x2DFA40 (NOT in PDB publics; confirmed by F4LoadTimeProfiler)
+	//   InitAllForms:        0x2EC830 (PDB: ?InitAllForms@TESDataHandler@@QEAAXXZ,
+	//                                  Sec=1, SecOff=0x2EB830, .text VA=0x1000)
+	//   NOTE: Prior value 0x2EB570 was SetMasterFileLargeBuffer (wrong function!)
+	//
+	// NG pipeline changes (1.11.191):
+	//   CompileFiles completes in ~50ms (vs ~10,000ms on OG) — now a lightweight
+	//   setup/metadata phase. The actual per-file loading was moved outside
+	//   CompileFiles into a deferred/restructured path.
+	//
+	//   ConstructObjectList was massively refactored (~594 bytes -> ~13,600 bytes).
+	//   On NG it fires only ONCE during CompileFiles with a null/placeholder file,
+	//   not once-per-file as on OG. The per-file loop was eliminated or moved.
+	//
+	//   CheckModsLoaded also grew from ~115 to ~3,984 bytes, suggesting the
+	//   loading orchestration was redistributed across multiple functions.
+	//
+	//   The ~3.5s between CompileFiles_End and GameDataReady corresponds to
+	//   form loading that previously happened inside CompileFiles on OG.
 	static constexpr uintptr_t kOG_ConstructObjectList_RVA = 0x118750;
 	static constexpr uintptr_t kOG_InitAllForms_RVA        = 0x11B070;
 	static constexpr uintptr_t kNG_CompileFiles_RVA         = 0x2E6C50;
 	static constexpr uintptr_t kNG_ConstructObjectList_RVA  = 0x2DFA40;
-	static constexpr uintptr_t kNG_InitAllForms_RVA         = 0; // disabled until known
+	static constexpr uintptr_t kNG_InitAllForms_RVA         = 0x2EC830; // PDB-confirmed
+
+	// NG-only: ConstructObject (per-form, not per-file) — potential per-form hook target
+	// Signature: bool ConstructObject(TESFile*, bool, TESForm*, bool)
+	// PDB: ?ConstructObject@TESDataHandler@@QEAA_NPEAVTESFile@@_NPEAVTESForm@@1@Z
+	static constexpr uintptr_t kNG_ConstructObject_RVA      = 0x2EA240;
 
 	// REL::ID for TESDataHandler::CompileFiles (OG only; NG uses direct RVA)
 	static constexpr std::uint32_t kCompileFilesID_OG = 57137;

--- a/Addictol/Source/AdProfilerMemory.cpp
+++ b/Addictol/Source/AdProfilerMemory.cpp
@@ -1,0 +1,72 @@
+#include <AdProfilerMemory.h>
+#include <AdProfilerCore.h>
+
+#include <Windows.h>
+#include <Psapi.h>
+
+#pragma comment(lib, "Psapi.lib")
+
+namespace Addictol
+{
+	void ProfilerMemory::CaptureBaseline() noexcept
+	{
+		if (!ProfilerCore::GetSingleton()->IsActive())
+			return;
+
+		PROCESS_MEMORY_COUNTERS pmc{};
+		pmc.cb = sizeof(pmc);
+
+		if (!GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
+		{
+			REX::WARN("[Profiler] Failed to capture memory baseline (error: {})"sv,
+				GetLastError());
+			return;
+		}
+
+		m_baselineWorkingSet = static_cast<std::size_t>(pmc.WorkingSetSize);
+		m_baselinePagefile = static_cast<std::size_t>(pmc.PagefileUsage);
+		m_baselinePeak = static_cast<std::size_t>(pmc.PeakWorkingSetSize);
+		m_baselineCaptured = true;
+
+		REX::INFO("[Profiler] Memory baseline captured: WS={} bytes, PF={} bytes, Peak={} bytes"sv,
+			m_baselineWorkingSet, m_baselinePagefile, m_baselinePeak);
+
+		// Submit the baseline as the first snapshot (delta = 0)
+		CaptureSnapshot("Baseline"sv);
+	}
+
+	void ProfilerMemory::CaptureSnapshot(std::string_view a_phaseName) noexcept
+	{
+		if (!ProfilerCore::GetSingleton()->IsActive())
+			return;
+
+		PROCESS_MEMORY_COUNTERS pmc{};
+		pmc.cb = sizeof(pmc);
+
+		if (!GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
+		{
+			REX::WARN("[Profiler] Failed to capture memory snapshot for '{}' (error: {})"sv,
+				a_phaseName, GetLastError());
+			return;
+		}
+
+		auto currentWS = static_cast<std::size_t>(pmc.WorkingSetSize);
+		auto currentPF = static_cast<std::size_t>(pmc.PagefileUsage);
+		auto currentPeak = static_cast<std::size_t>(pmc.PeakWorkingSetSize);
+
+		// Delta from baseline: net working set growth since baseline.
+		// Clamped to 0 if memory shrank (unsigned type safety).
+		std::size_t deltaWS = 0;
+		if (m_baselineCaptured && currentWS > m_baselineWorkingSet)
+			deltaWS = currentWS - m_baselineWorkingSet;
+
+		MemorySnapshot snapshot;
+		snapshot.phaseName      = std::string(a_phaseName);
+		snapshot.totalAllocated = currentWS;    // WorkingSetSize     (current physical memory)
+		snapshot.totalFreed     = currentPF;    // PagefileUsage      (committed virtual memory)
+		snapshot.peakUsage      = currentPeak;  // PeakWorkingSetSize (peak physical memory)
+		snapshot.allocationCount = deltaWS;     // WS delta from baseline (net growth in bytes)
+
+		ProfilerCore::GetSingleton()->AddMemorySnapshot(std::move(snapshot));
+	}
+}

--- a/Addictol/Source/AdProfilerModules.cpp
+++ b/Addictol/Source/AdProfilerModules.cpp
@@ -23,7 +23,7 @@ namespace Addictol
 
 	void ProfilerBeginModuleQuery(std::string_view a_name) noexcept
 	{
-		if (!ProfilerCore::GetSingleton()->IsActive())
+		if (!ProfilerCore::GetSingleton()->IsActive() || !ProfilerCore::IsModuleProfilingEnabled())
 			return;
 
 		s_startTimes[std::string(a_name)] = std::chrono::high_resolution_clock::now();
@@ -32,7 +32,7 @@ namespace Addictol
 	void ProfilerEndModuleQuery(std::string_view a_name, bool a_success) noexcept
 	{
 		auto profiler = ProfilerCore::GetSingleton();
-		if (!profiler->IsActive())
+		if (!profiler->IsActive() || !ProfilerCore::IsModuleProfilingEnabled())
 			return;
 
 		std::string name(a_name);
@@ -59,7 +59,7 @@ namespace Addictol
 
 	void ProfilerBeginModuleInstall(std::string_view a_name) noexcept
 	{
-		if (!ProfilerCore::GetSingleton()->IsActive())
+		if (!ProfilerCore::GetSingleton()->IsActive() || !ProfilerCore::IsModuleProfilingEnabled())
 			return;
 
 		s_startTimes[std::string(a_name)] = std::chrono::high_resolution_clock::now();
@@ -68,7 +68,7 @@ namespace Addictol
 	void ProfilerEndModuleInstall(std::string_view a_name, bool a_success) noexcept
 	{
 		auto profiler = ProfilerCore::GetSingleton();
-		if (!profiler->IsActive())
+		if (!profiler->IsActive() || !ProfilerCore::IsModuleProfilingEnabled())
 			return;
 
 		std::string name(a_name);

--- a/Addictol/Source/AdProfilerModules.cpp
+++ b/Addictol/Source/AdProfilerModules.cpp
@@ -1,0 +1,105 @@
+#include <AdProfilerModules.h>
+#include <AdProfilerCore.h>
+
+#include <chrono>
+#include <string>
+#include <unordered_map>
+
+namespace Addictol
+{
+	using namespace std::literals;
+
+	namespace
+	{
+		// Tracks the start time of the current operation per module name.
+		// Module init is single-threaded (main thread), so no synchronization needed.
+		std::unordered_map<std::string, std::chrono::high_resolution_clock::time_point> s_startTimes;
+
+		// Accumulates profiling data for modules between query and install phases.
+		// Entries are held here after query completes and submitted to ProfilerCore
+		// once install completes (or immediately if query fails).
+		std::unordered_map<std::string, ModuleProfileEntry> s_pendingEntries;
+	}
+
+	void ProfilerBeginModuleQuery(std::string_view a_name) noexcept
+	{
+		if (!ProfilerCore::GetSingleton()->IsActive())
+			return;
+
+		s_startTimes[std::string(a_name)] = std::chrono::high_resolution_clock::now();
+	}
+
+	void ProfilerEndModuleQuery(std::string_view a_name, bool a_success) noexcept
+	{
+		auto profiler = ProfilerCore::GetSingleton();
+		if (!profiler->IsActive())
+			return;
+
+		std::string name(a_name);
+		auto it = s_startTimes.find(name);
+		if (it == s_startTimes.end())
+			return;
+
+		auto elapsed = std::chrono::duration<double, std::milli>(
+			std::chrono::high_resolution_clock::now() - it->second).count();
+		s_startTimes.erase(it);
+
+		auto& entry = s_pendingEntries[name];
+		entry.moduleName = name;
+		entry.queryMs = elapsed;
+		entry.querySuccess = a_success;
+
+		// If query failed, the module won't be installed - submit immediately
+		if (!a_success)
+		{
+			profiler->AddModuleEntry(std::move(entry));
+			s_pendingEntries.erase(name);
+		}
+	}
+
+	void ProfilerBeginModuleInstall(std::string_view a_name) noexcept
+	{
+		if (!ProfilerCore::GetSingleton()->IsActive())
+			return;
+
+		s_startTimes[std::string(a_name)] = std::chrono::high_resolution_clock::now();
+	}
+
+	void ProfilerEndModuleInstall(std::string_view a_name, bool a_success) noexcept
+	{
+		auto profiler = ProfilerCore::GetSingleton();
+		if (!profiler->IsActive())
+			return;
+
+		std::string name(a_name);
+		auto it = s_startTimes.find(name);
+		if (it == s_startTimes.end())
+			return;
+
+		auto elapsed = std::chrono::duration<double, std::milli>(
+			std::chrono::high_resolution_clock::now() - it->second).count();
+		s_startTimes.erase(it);
+
+		auto& entry = s_pendingEntries[name];
+		entry.moduleName = name;
+		entry.installMs = elapsed;
+		entry.installSuccess = a_success;
+
+		// Install is the final phase - submit the completed entry
+		profiler->AddModuleEntry(std::move(entry));
+		s_pendingEntries.erase(name);
+	}
+
+	void ProfilerFlushModuleEntries() noexcept
+	{
+		auto profiler = ProfilerCore::GetSingleton();
+		if (!profiler->IsActive())
+			return;
+
+		for (auto& [name, entry] : s_pendingEntries)
+			profiler->AddModuleEntry(std::move(entry));
+
+		s_pendingEntries.clear();
+		s_startTimes.clear();
+	}
+}

--- a/Addictol/Source/AdRegisterModules.cpp
+++ b/Addictol/Source/AdRegisterModules.cpp
@@ -46,6 +46,7 @@
 #include <Modules/AdModuleSaveAddedSoundCategories.h>
 #include <Modules/AdModuleCOMInit.h>
 #include <Modules/AdModulePapyrusGC.h>
+#include <Modules/AdModuleProfiler.h>
 
 // Create patches
 static auto sModuleThreads							= std::make_shared<Addictol::ModuleThreads>();
@@ -94,6 +95,7 @@ static auto sModuleStolenPowerArmorOwnership		= std::make_shared<Addictol::Modul
 static auto sModuleSaveAddedSoundCategories			= std::make_shared<Addictol::ModuleSaveAddedSoundCategories>();
 static auto sModuleCOMInit							= std::make_shared<Addictol::ModuleCOMInit>();
 static auto sModulePapyrusGC						= std::make_shared<Addictol::ModulePapyrusGC>();
+static auto sModuleProfiler							= std::make_shared<Addictol::ModuleProfiler>();
 
 void AdRegisterPreloadModules()
 {
@@ -172,4 +174,8 @@ void AdRegisterModules()
 	modules.Register(sModuleSaveAddedSoundCategories,	kGameLoaded);
 	modules.Register(sModuleMaxPapyrusOps,				kPostLoad);
 	modules.Register(sModulePapyrusGC,					kPostLoad);
+
+	// Profiler - registered at load stage, listener at GameDataReady for report generation
+	modules.Register(sModuleProfiler);
+	modules.Register(sModuleProfiler,					kGameDataReady);
 }

--- a/Addictol/Source/Modules/AdModuleLibDeflate.cpp
+++ b/Addictol/Source/Modules/AdModuleLibDeflate.cpp
@@ -64,7 +64,7 @@ namespace Addictol
 					thread_local libdeflate_decompressor* decompressor = libdeflate_alloc_decompressor();
 					if (!decompressor) return Z_MEM_ERROR;
 
-					const bool profiling = ProfilerCore::GetSingleton()->IsActive();
+					const bool profiling = ProfilerCore::GetSingleton()->IsActive() && ProfilerCore::IsBA2TimingEnabled();
 					std::chrono::high_resolution_clock::time_point profStart;
 					if (profiling)
 						profStart = std::chrono::high_resolution_clock::now();

--- a/Addictol/Source/Modules/AdModuleLibDeflate.cpp
+++ b/Addictol/Source/Modules/AdModuleLibDeflate.cpp
@@ -1,6 +1,7 @@
 #include <Modules/AdModuleLibDeflate.h>
 #include <AdUtils.h>
 #include <AdAssert.h>
+#include <AdProfilerBA2.h>
 #include <libdeflate/libdeflate.h>
 
 namespace Addictol
@@ -49,9 +50,6 @@ namespace Addictol
 					if (!a_stream) return Z_STREAM_ERROR;
 
 					thread_local static bool streaming = false;
-#if 0
-					Timer profiler;
-#endif
 
 					// If the stream is registered as streaming, we call the original function....
 					if (streaming)
@@ -66,12 +64,24 @@ namespace Addictol
 					thread_local libdeflate_decompressor* decompressor = libdeflate_alloc_decompressor();
 					if (!decompressor) return Z_MEM_ERROR;
 
+					const bool profiling = ProfilerCore::GetSingleton()->IsActive();
+					std::chrono::high_resolution_clock::time_point profStart;
+					if (profiling)
+						profStart = std::chrono::high_resolution_clock::now();
+
 					size_t inBytes = 0, outBytes = 0;
 					libdeflate_result result = libdeflate_zlib_decompress_ex(decompressor, a_stream->next_in, a_stream->avail_in,
 						a_stream->next_out, a_stream->avail_out, &inBytes, &outBytes);
 
 					if (result == LIBDEFLATE_SUCCESS)
 					{
+						if (profiling)
+						{
+							auto profEnd = std::chrono::high_resolution_clock::now();
+							double elapsedMs = std::chrono::duration<double, std::milli>(profEnd - profStart).count();
+							ProfilerBA2::GetSingleton()->RecordDecompression(inBytes, outBytes, elapsedMs);
+						}
+
 						AdAssert(outBytes < std::numeric_limits<uint32_t>::max());
 
 						a_stream->next_in += (uint32_t)inBytes;

--- a/Addictol/Source/Modules/AdModuleProfiler.cpp
+++ b/Addictol/Source/Modules/AdModuleProfiler.cpp
@@ -24,6 +24,22 @@ namespace Addictol
 		if (!profiler->IsActive())
 			profiler->Start();
 
+		// On kGameDataReady: generate the report (this is the second DoInstall call)
+		if (a_msg && a_msg->type == F4SE::MessagingInterface::kGameDataReady)
+		{
+			if (profiler->IsActive())
+			{
+				if (ProfilerCore::IsMemoryTrackingEnabled())
+					ProfilerMemory::GetSingleton()->CaptureSnapshot("GameDataReady"sv);
+
+				profiler->MarkPhase("GameDataReady"sv);
+				profiler->GenerateReport();
+			}
+			return true;
+		}
+
+		// First call (load stage): install sub-profiler hooks
+
 		// Install ESP/ESM load profiler hooks (only if enabled in config)
 		if (profiler->IsESPEnabled())
 		{
@@ -57,20 +73,8 @@ namespace Addictol
 
 	bool ModuleProfiler::DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
 	{
-		if (a_msg && a_msg->type == F4SE::MessagingInterface::kGameDataReady)
-		{
-			auto profiler = ProfilerCore::GetSingleton();
-			if (profiler->IsActive())
-			{
-				// Capture final memory snapshot
-				if (ProfilerCore::IsMemoryTrackingEnabled())
-					ProfilerMemory::GetSingleton()->CaptureSnapshot("GameDataReady"sv);
-
-				profiler->MarkPhase("GameDataReady"sv);
-				profiler->GenerateReport();
-			}
-		}
-
+		// kGameDataReady fires before kGameLoaded, so DoListener is never
+		// called for it. Report generation is handled in DoInstall above.
 		return true;
 	}
 

--- a/Addictol/Source/Modules/AdModuleProfiler.cpp
+++ b/Addictol/Source/Modules/AdModuleProfiler.cpp
@@ -1,0 +1,70 @@
+#include <Modules/AdModuleProfiler.h>
+#include <AdProfilerCore.h>
+#include <AdProfilerESP.h>
+#include <AdProfilerDLL.h>
+#include <AdProfilerMemory.h>
+#include <AdUtils.h>
+
+namespace Addictol
+{
+	static REX::TOML::Bool<> bProfilerEnabled{ "Profiler"sv, "bProfiler"sv, false };
+
+	ModuleProfiler::ModuleProfiler() :
+		Module("Profiler", &bProfilerEnabled, { F4SE::MessagingInterface::kGameDataReady })
+	{}
+
+	bool ModuleProfiler::DoQuery() const noexcept
+	{
+		return true;
+	}
+
+	bool ModuleProfiler::DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		auto profiler = ProfilerCore::GetSingleton();
+		if (!profiler->IsActive())
+			profiler->Start();
+
+		// Install ESP/ESM load profiler hooks
+		auto espProfiler = ESPProfiler::GetSingleton();
+		if (!espProfiler->IsInstalled())
+		{
+			espProfiler->Install();
+			if (espProfiler->IsInstalled())
+				REX::INFO("[Profiler] ESP/ESM profiler hooks installed"sv);
+		}
+
+		// Capture memory baseline
+		auto memProfiler = ProfilerMemory::GetSingleton();
+		if (!memProfiler->HasBaseline())
+		{
+			memProfiler->CaptureBaseline();
+			REX::INFO("[Profiler] Memory baseline captured"sv);
+		}
+
+		REX::INFO("[Profiler] Module installed, profiling active"sv);
+		return true;
+	}
+
+	bool ModuleProfiler::DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		if (a_msg && a_msg->type == F4SE::MessagingInterface::kGameDataReady)
+		{
+			auto profiler = ProfilerCore::GetSingleton();
+			if (profiler->IsActive())
+			{
+				// Capture final memory snapshot
+				ProfilerMemory::GetSingleton()->CaptureSnapshot("GameDataReady"sv);
+
+				profiler->MarkPhase("GameDataReady"sv);
+				profiler->GenerateReport();
+			}
+		}
+
+		return true;
+	}
+
+	bool ModuleProfiler::DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept
+	{
+		return true;
+	}
+}

--- a/Addictol/Source/Modules/AdModuleProfiler.cpp
+++ b/Addictol/Source/Modules/AdModuleProfiler.cpp
@@ -24,21 +24,31 @@ namespace Addictol
 		if (!profiler->IsActive())
 			profiler->Start();
 
-		// Install ESP/ESM load profiler hooks
-		auto espProfiler = ESPProfiler::GetSingleton();
-		if (!espProfiler->IsInstalled())
+		// Install ESP/ESM load profiler hooks (only if enabled in config)
+		if (profiler->IsESPEnabled())
 		{
-			espProfiler->Install();
-			if (espProfiler->IsInstalled())
-				REX::INFO("[Profiler] ESP/ESM profiler hooks installed"sv);
+			auto espProfiler = ESPProfiler::GetSingleton();
+			if (!espProfiler->IsInstalled())
+			{
+				espProfiler->Install();
+				if (espProfiler->IsInstalled())
+					REX::INFO("[Profiler] ESP/ESM profiler hooks installed"sv);
+			}
+		}
+		else
+		{
+			REX::INFO("[Profiler] ESP profiler disabled in config"sv);
 		}
 
-		// Capture memory baseline
-		auto memProfiler = ProfilerMemory::GetSingleton();
-		if (!memProfiler->HasBaseline())
+		// Capture memory baseline (only if memory tracking enabled)
+		if (ProfilerCore::IsMemoryTrackingEnabled())
 		{
-			memProfiler->CaptureBaseline();
-			REX::INFO("[Profiler] Memory baseline captured"sv);
+			auto memProfiler = ProfilerMemory::GetSingleton();
+			if (!memProfiler->HasBaseline())
+			{
+				memProfiler->CaptureBaseline();
+				REX::INFO("[Profiler] Memory baseline captured"sv);
+			}
 		}
 
 		REX::INFO("[Profiler] Module installed, profiling active"sv);
@@ -53,7 +63,8 @@ namespace Addictol
 			if (profiler->IsActive())
 			{
 				// Capture final memory snapshot
-				ProfilerMemory::GetSingleton()->CaptureSnapshot("GameDataReady"sv);
+				if (ProfilerCore::IsMemoryTrackingEnabled())
+					ProfilerMemory::GetSingleton()->CaptureSnapshot("GameDataReady"sv);
 
 				profiler->MarkPhase("GameDataReady"sv);
 				profiler->GenerateReport();

--- a/Addictol/Source/Modules/AdModuleProfiler.cpp
+++ b/Addictol/Source/Modules/AdModuleProfiler.cpp
@@ -73,8 +73,9 @@ namespace Addictol
 
 	bool ModuleProfiler::DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
 	{
-		// kGameDataReady fires before kGameLoaded, so DoListener is never
-		// called for it. Report generation is handled in DoInstall above.
+		// Dead code: kGameDataReady fires before kGameLoaded, so DoListener
+		// is never invoked for it. Report generation lives in DoInstall.
+		// Override kept to satisfy the Module interface contract.
 		return true;
 	}
 

--- a/VC/Addictol.vcxproj
+++ b/VC/Addictol.vcxproj
@@ -15,8 +15,14 @@
     <ClCompile Include="..\Addictol\Source\AdModule.cpp" />
     <ClCompile Include="..\Addictol\Source\AdModuleManager.cpp" />
     <ClCompile Include="..\Addictol\Source\AdPlugin.cpp" />
+    <ClCompile Include="..\Addictol\Source\AdProfilerCore.cpp" />
+    <ClCompile Include="..\Addictol\Source\AdProfilerMemory.cpp" />
+    <ClCompile Include="..\Addictol\Source\AdProfilerBA2.cpp" />
+    <ClCompile Include="..\Addictol\Source\AdProfilerModules.cpp" />
     <ClCompile Include="..\Addictol\Source\AdProxyVoltekHeap.cpp" />
     <ClCompile Include="..\Addictol\Source\AdRegisterModules.cpp" />
+    <ClCompile Include="..\Addictol\Source\AdProfilerDLL.cpp" />
+    <ClCompile Include="..\Addictol\Source\AdProfilerESP.cpp" />
     <ClCompile Include="..\Addictol\Source\AdUtils.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleAchievements.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleActorIsHostileToActor.cpp" />
@@ -55,6 +61,7 @@
     <ClCompile Include="..\Addictol\Source\Modules\AdModulePackageAllocateLocation.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModulePipBoyLightInv.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleProfile.cpp" />
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleProfiler.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleSafeExit.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleSaveAddedSoundCategories.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleSmallblockAllocator.cpp" />
@@ -72,7 +79,13 @@
     <ClInclude Include="..\Addictol\Include\AdMemoryTracer.h" />
     <ClInclude Include="..\Addictol\Include\AdModule.h" />
     <ClInclude Include="..\Addictol\Include\AdModuleManager.h" />
+    <ClInclude Include="..\Addictol\Include\AdProfilerCore.h" />
+    <ClInclude Include="..\Addictol\Include\AdProfilerMemory.h" />
+    <ClInclude Include="..\Addictol\Include\AdProfilerBA2.h" />
     <ClInclude Include="..\Addictol\Include\AdPlugin.h" />
+    <ClInclude Include="..\Addictol\Include\AdProfilerModules.h" />
+    <ClInclude Include="..\Addictol\Include\AdProfilerDLL.h" />
+    <ClInclude Include="..\Addictol\Include\AdProfilerESP.h" />
     <ClInclude Include="..\Addictol\Include\AdUtils.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleAchievements.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleActorIsHostileToActor.h" />
@@ -111,6 +124,7 @@
     <ClInclude Include="..\Addictol\Include\Modules\AdModulePackageAllocateLocation.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModulePipBoyLightInv.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleProfile.h" />
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleProfiler.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleSafeExit.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleSaveAddedSoundCategories.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleScaleformAllocator.h" />


### PR DESCRIPTION
Add a new Performance Profiler module (AdModuleProfiler) that provides deep diagnostic profiling of Fallout 4 load times. Toggled via [Profiler] section in Addictol.toml (disabled by default).

Components:
- ESP/ESM Load Profiler: hooks TESDataHandler::CompileFiles, ConstructObjectList, and InitAllForms to measure per-file load times with configurable warning thresholds (OG/NG support via call-site scanning)
- DLL Profiler: IAT hooks GetProcAddress in F4SE to time every other F4SE plugin's Query/Load calls with version info extraction
- Module Profiler: instruments ModuleManager to time each Addictol module's DoQuery and DoInstall phases
- Memory Tracker: captures process memory snapshots (working set, pagefile, peak) at each loading phase via GetProcessMemoryInfo
- BA2 Timing: instruments the libdeflate decompression hook to measure per-chunk decompression time and throughput (thread-safe)
- Startup Timeline: marks timestamps at every lifecycle phase from config load through GameDataReady
- CSV Export: exports all profiling data to timestamped CSV files in Data/F4SE/Plugins/Addictol/Profiler/

whats left
find constructobjectlist, initallforms
need to find correct REL::ID for CompileFiles on NG/AE and update that in AdPRofilerESP.cpp line 105