### PR TITLE
Save Compression Module

### DIFF
--- a/.Build/F4SE/Plugins/Addictol.toml
+++ b/.Build/F4SE/Plugins/Addictol.toml
@@ -59,6 +59,9 @@ bHighResBloom = false
 # Marks the process as DPI-aware so menus and cursor track correctly on high-DPI desktops.
 bDpiScaling = true
 
+# Swaps the engine's save compression to libdeflate (zlib level 6) for faster, slightly smaller saves.
+bSaveCompression = true
+
 
 [Fixes]
 

--- a/Addictol/Include/Modules/AdModuleSaveCompression.h
+++ b/Addictol/Include/Modules/AdModuleSaveCompression.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <AdModule.h>
+
+namespace Addictol
+{
+	class ModuleSaveCompression :
+		public Module
+	{
+	public:
+		ModuleSaveCompression();
+		virtual ~ModuleSaveCompression() = default;
+
+		[[nodiscard]] virtual bool DoQuery() const noexcept override;
+		[[nodiscard]] virtual bool DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept override;
+	};
+}

--- a/Addictol/Source/AdConfigValidation.cpp
+++ b/Addictol/Source/AdConfigValidation.cpp
@@ -17,7 +17,8 @@ namespace Addictol
 			"bFacegen", "bMemoryManager", "bSmallBlockAllocator", "bScaleformAllocator",
 			"bBSMTAManager", "bBSPreCulledObjects", "bINISettingCollection",
 			"bArchiveLimits", "bInputSwitch", "bFasterWorkshop",
-			"bSaveAddedSoundCategories", "bCOMInit", "bHighResBloom", "bDpiScaling"
+			"bSaveAddedSoundCategories", "bCOMInit", "bHighResBloom", "bDpiScaling",
+			"bSaveCompression"
 		}},
 		{ "Fixes", {
 			"bGreyMovie", "bPackageAllocateLocation", "bInitTints", "bLODDistance",

--- a/Addictol/Source/AdRegisterModules.cpp
+++ b/Addictol/Source/AdRegisterModules.cpp
@@ -4,6 +4,7 @@
 #include <Modules/AdModuleGreyMovie.h>
 #include <Modules/AdModulePackageAllocateLocation.h>
 #include <Modules/AdModuleLibDeflate.h>
+#include <Modules/AdModuleSaveCompression.h>
 #include <Modules/AdModuleProfile.h>
 #include <Modules/AdModuleLoadScreen.h>
 #include <Modules/AdModuleAchievements.h>
@@ -71,6 +72,7 @@ static auto sModuleThreads							= std::make_shared<Addictol::ModuleThreads>();
 static auto sModuleGreyMovie						= std::make_shared<Addictol::ModuleGreyMovie>();
 static auto sModulePackageAllocateLocation			= std::make_shared<Addictol::ModulePackageAllocateLocation>();
 static auto sModuleLibDeflate						= std::make_shared<Addictol::ModuleLibDeflate>();
+static auto sModuleSaveCompression					= std::make_shared<Addictol::ModuleSaveCompression>();
 static auto sModuleProfile							= std::make_shared<Addictol::ModuleProfile>();
 static auto sModuleLoadScreen						= std::make_shared<Addictol::ModuleLoadScreen>();
 static auto sModuleAchievements						= std::make_shared<Addictol::ModuleAchievements>();
@@ -164,6 +166,7 @@ void AdRegisterModules()
 	modules.Register(sModuleGreyMovie);
 	modules.Register(sModulePackageAllocateLocation);
 	modules.Register(sModuleLibDeflate);
+	modules.Register(sModuleSaveCompression);
 	modules.Register(sModuleProfile);
 	modules.Register(sModuleAchievements);
 	modules.Register(sModuleLODDistance);

--- a/Addictol/Source/Modules/AdModuleSaveCompression.cpp
+++ b/Addictol/Source/Modules/AdModuleSaveCompression.cpp
@@ -1,0 +1,73 @@
+#include <Modules/AdModuleSaveCompression.h>
+#include <AdUtils.h>
+#include <libdeflate/libdeflate.h>
+
+#include <cstring>
+
+namespace Addictol
+{
+	static REX::TOML::Bool<> bPatchesSaveCompression{ "Patches"sv, "bSaveCompression"sv, true };
+
+	namespace saveCompDetail
+	{
+		// Engine zlib CompressBuffer, kept as a fallback if a libdeflate compressor can't be allocated.
+		using TCompressBuffer = std::uint32_t(*)(void*, std::uint32_t, void*, std::uint32_t) noexcept;
+		TCompressBuffer CompressBufferOrig;
+
+		// libdeflate (zlib, level 6) replacement for BGSSaveLoadUtilities::CompressBuffer.
+		static std::uint32_t CompressBuffer(void* a_src, std::uint32_t a_srcLen, void* a_dst, std::uint32_t a_dstCap) noexcept
+		{
+			if (a_srcLen < 0x20)
+				return 0;
+
+			thread_local libdeflate_compressor* compressor = libdeflate_alloc_compressor(6);
+			if (!compressor)
+				return CompressBufferOrig(a_src, a_srcLen, a_dst, a_dstCap);
+
+			// Engine caps output at min(dstCap, srcLen-1); a 0 return means store uncompressed.
+			const std::size_t bound	  = (a_dstCap < a_srcLen - 1) ? a_dstCap : (a_srcLen - 1);
+			const std::size_t written = libdeflate_zlib_compress(compressor, a_src, a_srcLen, a_dst, bound);
+			return static_cast<std::uint32_t>(written);
+		}
+	}
+
+	ModuleSaveCompression::ModuleSaveCompression() :
+		Module("Save Compression", &bPatchesSaveCompression)
+	{}
+
+	bool ModuleSaveCompression::DoQuery() const noexcept
+	{
+		return true;
+	}
+
+	bool ModuleSaveCompression::DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		const auto target = REL::Relocation<std::uintptr_t>{ REL::ID{ 104318, 2228204, 2228204 } }.address();
+
+		// CompressBuffer prologue, byte-identical OG/NG/AE.
+		static constexpr std::uint8_t expected[] = {
+			0x48, 0x8B, 0xC4, 0x48, 0x89, 0x68, 0x10, 0x48, 0x89, 0x70, 0x18, 0x48, 0x89, 0x78, 0x20,
+			0x41, 0x56, 0x48, 0x81, 0xEC, 0x90, 0x00, 0x00, 0x00, 0x33, 0xFF, 0x49, 0x8B, 0xE8, 0x8B,
+			0xF2, 0x4C, 0x8B, 0xF1
+		};
+		if (std::memcmp(reinterpret_cast<const void*>(target), expected, sizeof(expected)) != 0)
+		{
+			REX::WARN("Save Compression: unexpected prologue at CompressBuffer -- skipping to avoid corruption."sv);
+			return false;
+		}
+
+		saveCompDetail::CompressBufferOrig = reinterpret_cast<saveCompDetail::TCompressBuffer>(
+			RELEX::DetourJump(target, reinterpret_cast<std::uintptr_t>(&saveCompDetail::CompressBuffer)));
+		return true;
+	}
+
+	bool ModuleSaveCompression::DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		return true;
+	}
+
+	bool ModuleSaveCompression::DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept
+	{
+		return true;
+	}
+}

--- a/VC/Addictol.vcxproj
+++ b/VC/Addictol.vcxproj
@@ -63,6 +63,7 @@
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleIOCacher.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleLeveledListCrash.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleLibDeflate.cpp" />
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleSaveCompression.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleLoadScreen.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleLODDistance.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleMagicEffectApplyEvent.cpp" />
@@ -145,6 +146,7 @@
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleIOCacher.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleLeveledListCrash.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleLibDeflate.h" />
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleSaveCompression.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleLoadScreen.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleLODDistance.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleMagicEffectApplyEvent.h" />

--- a/VC/Addictol.vcxproj.filters
+++ b/VC/Addictol.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleLibDeflate.cpp">
       <Filter>Source\Modules</Filter>
     </ClCompile>
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleSaveCompression.cpp">
+      <Filter>Source\Modules</Filter>
+    </ClCompile>
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleInitTints.cpp">
       <Filter>Source\Modules</Filter>
     </ClCompile>
@@ -275,6 +278,9 @@
       <Filter>Include\Modules</Filter>
     </ClInclude>
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleLibDeflate.h">
+      <Filter>Include\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleSaveCompression.h">
       <Filter>Include\Modules</Filter>
     </ClInclude>
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleLoadScreen.h">


### PR DESCRIPTION
Swaps the engine's save-buffer compression to libdeflate (zlib, level 6) — the
compress-side counterpart to the existing `bLibDeflate` decompression swap.

- Detours `BGSSaveLoadUtilities::CompressBuffer`, guarded by a byte-signature
  check that skips cleanly if the prologue doesn't match (OG/NG/AE).
- Output stays standard zlib, so saves load fine with or without the mod — no
  format lock-in.
- Reuses the libdeflate dependency already in the tree; no new deps.
- Toggle: `bSaveCompression` under `[Patches]`.