### PR TITLE
Add three fix modules: WaterJetpackFix, NoEssentialDecapitation, Nega…

### DIFF
--- a/.Build/F4SE/Plugins/Addictol.toml
+++ b/.Build/F4SE/Plugins/Addictol.toml
@@ -221,6 +221,15 @@ bLoadOrder = true
 # Fixes a crash related to queued HUD messages on NG & AE.
 bHUDMessageQueue = true
 
+# Fixes a bug where exiting water while using a jetpack leaves the player in a broken jump state (cannot jump or fly normally until reload).
+bWaterJetpackFix = true
+
+# Prevents Essential and alive Protected NPCs from being decapitated by scripted or weapon-driven dismemberment.
+bNoEssentialDecapitation = true
+
+# Blocks writes that would set an NPC's base health to a negative value, which causes immortal/unkillable actors and other health-bar corruption.
+bNegativeHealthFix = true
+
 
 [Warnings]
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/brofield/simpleini.git
 [submodule "Depends/commonlibf4"]
 	path = Depends/commonlibf4
-	url = https://github.com/Dear-Modding-FO4/commonlibf4.git
+	url = https://github.com/passed111/commonlibf4.git

--- a/Addictol/Include/Modules/AdModuleNegativeHealthFix.h
+++ b/Addictol/Include/Modules/AdModuleNegativeHealthFix.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <AdModule.h>
+
+namespace Addictol
+{
+	class ModuleNegativeHealthFix :
+		public Module
+	{
+	public:
+		ModuleNegativeHealthFix();
+		virtual ~ModuleNegativeHealthFix() = default;
+
+		[[nodiscard]] virtual bool DoQuery() const noexcept override;
+		[[nodiscard]] virtual bool DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept override;
+	};
+}

--- a/Addictol/Include/Modules/AdModuleNoEssentialDecapitation.h
+++ b/Addictol/Include/Modules/AdModuleNoEssentialDecapitation.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <AdModule.h>
+
+namespace Addictol
+{
+	class ModuleNoEssentialDecapitation :
+		public Module
+	{
+	public:
+		ModuleNoEssentialDecapitation();
+		virtual ~ModuleNoEssentialDecapitation() = default;
+
+		[[nodiscard]] virtual bool DoQuery() const noexcept override;
+		[[nodiscard]] virtual bool DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept override;
+	};
+}

--- a/Addictol/Include/Modules/AdModuleWaterJetpackFix.h
+++ b/Addictol/Include/Modules/AdModuleWaterJetpackFix.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <AdModule.h>
+
+namespace Addictol
+{
+	class ModuleWaterJetpackFix :
+		public Module
+	{
+	public:
+		ModuleWaterJetpackFix();
+		virtual ~ModuleWaterJetpackFix() = default;
+
+		[[nodiscard]] virtual bool DoQuery() const noexcept override;
+		[[nodiscard]] virtual bool DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+		[[nodiscard]] virtual bool DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept override;
+	};
+}

--- a/Addictol/Source/AdRegisterModules.cpp
+++ b/Addictol/Source/AdRegisterModules.cpp
@@ -78,6 +78,9 @@
 #include <Modules/AdModuleLoadOrder.h>
 #include <Modules/AdModuleHUDMessageQueue.h>
 #include <Modules/AdModuleProcessIcon.h>
+#include <Modules/AdModuleWaterJetpackFix.h>
+#include <Modules/AdModuleNoEssentialDecapitation.h>
+#include <Modules/AdModuleNegativeHealthFix.h>
 
 // Create patches
 static auto sModuleThreads							= std::make_shared<Addictol::ModuleThreads>();
@@ -158,6 +161,9 @@ static auto sModuleStringPoolRelease				= std::make_shared<Addictol::ModuleStrin
 static auto sModuleLoadOrder						= std::make_shared<Addictol::ModuleLoadOrder>();
 static auto sModuleHUDMessageQueue					= std::make_shared<Addictol::ModuleHUDMessageQueue>();
 static auto sModuleProcessIcon						= std::make_shared<Addictol::ModuleProcessIcon>();
+static auto sModuleWaterJetpackFix					= std::make_shared<Addictol::ModuleWaterJetpackFix>();
+static auto sModuleNoEssentialDecapitation			= std::make_shared<Addictol::ModuleNoEssentialDecapitation>();
+static auto sModuleNegativeHealthFix				= std::make_shared<Addictol::ModuleNegativeHealthFix>();
 
 void AdRegisterPreloadModules()
 {
@@ -261,6 +267,9 @@ void AdRegisterModules()
 	modules.Register(sModuleCombatMusic,					kGameDataReady);
 	modules.Register(sModulePipBoyCursorConstraints,		kGameDataReady);
 	modules.Register(sModuleCompanionStrayBullet,			kGameDataReady);
+	modules.Register(sModuleWaterJetpackFix,				kGameDataReady);
+	modules.Register(sModuleNoEssentialDecapitation,		kGameDataReady);
+	modules.Register(sModuleNegativeHealthFix,				kGameDataReady);
 	modules.Register(sModuleEncounterZoneReset,				kGameLoaded);
 	modules.Register(sModuleInputSwitch,					kGameLoaded);
 	modules.Register(sModuleLoadScreen,						kGameLoaded);

--- a/Addictol/Source/Modules/AdModuleNegativeHealthFix.cpp
+++ b/Addictol/Source/Modules/AdModuleNegativeHealthFix.cpp
@@ -4,7 +4,7 @@
 #include <RE/A/Actor.h>
 #include <RE/A/ActorValue.h>
 #include <RE/A/ActorValueOwner.h>
-#include <RE/T/TESNPC.h>
+#include <RE/P/PlayerCharacter.h>
 
 namespace Addictol
 {
@@ -12,14 +12,19 @@ namespace Addictol
 
 	namespace negativeHealthFixDetail
 	{
-		// ActorValueOwner sub-object offset within Actor/TESObjectREFR
-		constexpr uintptr_t kAVOwnerOffset = 0x58;
-
-		// ActorValueOwner vtable layout:
+		// ActorValueOwner vtable layout (slot indices within a single vtable):
 		//   00 dtor, 01 GetActorValue, 02 GetPermanentActorValue,
 		//   03 GetBaseActorValue, 04 SetBaseActorValue, 05 ModBaseActorValue,
 		//   06 ModActorValue, 07 GetModifier, 08 RestoreActorValue,
 		//   09 SetActorValue, 0A GetIsPlayerOwner
+		//
+		// ActorValueOwner is a __declspec(novtable) sub-object: its base vtable
+		// (RE::VTABLE::ActorValueOwner[0]) is never assigned to any instance.
+		// Actual actors use the sub-object vtable inherited via TESObjectREFR,
+		// which sits at index 7 in the Actor / PlayerCharacter vtable groups:
+		//   0 TESForm, 1 BSHandleRefObject, 2-4 BSTEventSink x3,
+		//   5 IAnimationGraphManagerHolder, 6 IKeywordFormBase, 7 ActorValueOwner
+		// (BSTEventSource has no virtual functions → no vtable slot)
 		using SetBaseAV_t = void(RE::ActorValueOwner*, const RE::ActorValueInfo&, float);
 		using ModBaseAV_t = void(RE::ActorValueOwner*, const RE::ActorValueInfo&, float);
 
@@ -60,12 +65,21 @@ namespace Addictol
 			}
 			g_healthAV = av->health;
 
-			// Hook ActorValueOwner vtable (shared by all actors including PlayerCharacter)
-			REL::Relocation<std::uintptr_t> vtbl{ RE::VTABLE::ActorValueOwner[0] };
-			g_origSetBaseAV = reinterpret_cast<SetBaseAV_t*>(vtbl.write_vfunc(4, &HookedSetBaseActorValue));
-			g_origModBaseAV = reinterpret_cast<ModBaseAV_t*>(vtbl.write_vfunc(5, &HookedModBaseActorValue));
+			// Hook the ActorValueOwner sub-object vtable from Actor's vtable group
+			// (index 7). Actor[7] covers all Actor instances (NPCs, creatures).
+			REL::Relocation<std::uintptr_t> vtblActor{ RE::VTABLE::Actor[7] };
+			g_origSetBaseAV = reinterpret_cast<SetBaseAV_t*>(vtblActor.write_vfunc(4, &HookedSetBaseActorValue));
+			g_origModBaseAV = reinterpret_cast<ModBaseAV_t*>(vtblActor.write_vfunc(5, &HookedModBaseActorValue));
 
-			REX::INFO("NegativeHealthFix: ActorValueOwner hooks installed (SetBaseAV + ModBaseAV)"sv);
+			// PlayerCharacter has its own vtable copy — hook it separately so the
+			// player is covered too. The original function pointer is the same as
+			// Actor's (PlayerCharacter does not override these slots), so g_orig*
+			// saved above is correct for both.
+			REL::Relocation<std::uintptr_t> vtblPlayer{ RE::VTABLE::PlayerCharacter[7] };
+			vtblPlayer.write_vfunc(4, &HookedSetBaseActorValue);
+			vtblPlayer.write_vfunc(5, &HookedModBaseActorValue);
+
+			REX::INFO("NegativeHealthFix: ActorValueOwner hooks installed (Actor + PlayerCharacter, SetBaseAV + ModBaseAV)"sv);
 		}
 	}
 

--- a/Addictol/Source/Modules/AdModuleNegativeHealthFix.cpp
+++ b/Addictol/Source/Modules/AdModuleNegativeHealthFix.cpp
@@ -1,0 +1,103 @@
+#include <Modules/AdModuleNegativeHealthFix.h>
+#include <AdUtils.h>
+
+#include <RE/A/Actor.h>
+#include <RE/A/ActorValue.h>
+#include <RE/A/ActorValueOwner.h>
+#include <RE/T/TESNPC.h>
+
+namespace Addictol
+{
+	static REX::TOML::Bool<> bFixesNegativeHealthFix{ "Fixes"sv, "bNegativeHealthFix"sv, true };
+
+	namespace negativeHealthFixDetail
+	{
+		// ActorValueOwner sub-object offset within Actor/TESObjectREFR
+		constexpr uintptr_t kAVOwnerOffset = 0x58;
+
+		// ActorValueOwner vtable layout:
+		//   00 dtor, 01 GetActorValue, 02 GetPermanentActorValue,
+		//   03 GetBaseActorValue, 04 SetBaseActorValue, 05 ModBaseActorValue,
+		//   06 ModActorValue, 07 GetModifier, 08 RestoreActorValue,
+		//   09 SetActorValue, 0A GetIsPlayerOwner
+		using SetBaseAV_t = void(RE::ActorValueOwner*, const RE::ActorValueInfo&, float);
+		using ModBaseAV_t = void(RE::ActorValueOwner*, const RE::ActorValueInfo&, float);
+
+		static SetBaseAV_t* g_origSetBaseAV = nullptr;
+		static ModBaseAV_t* g_origModBaseAV = nullptr;
+
+		// Cache health AV pointer to avoid GetSingleton() lookup on every call
+		static const RE::ActorValueInfo* g_healthAV = nullptr;
+
+		static void HookedSetBaseActorValue(RE::ActorValueOwner* a_owner,
+			const RE::ActorValueInfo& a_av, float a_value)
+		{
+			if (&a_av == g_healthAV && a_value < 0.0f)
+				return;  // Block the write — would set health base negative
+			g_origSetBaseAV(a_owner, a_av, a_value);
+		}
+
+		static void HookedModBaseActorValue(RE::ActorValueOwner* a_owner,
+			const RE::ActorValueInfo& a_av, float a_delta)
+		{
+			if (&a_av == g_healthAV)
+			{
+				float currentBase = a_owner->GetBaseActorValue(a_av);
+				float newBase = currentBase + a_delta;
+				if (newBase < 0.0f)
+					return;  // Block the write — would push health base negative
+			}
+			g_origModBaseAV(a_owner, a_av, a_delta);
+		}
+
+		static void InstallHooks() noexcept
+		{
+			auto* av = RE::ActorValue::GetSingleton();
+			if (!av || !av->health)
+			{
+				REX::ERROR("NegativeHealthFix: failed to get health ActorValueInfo, hooks not installed"sv);
+				return;
+			}
+			g_healthAV = av->health;
+
+			// Hook ActorValueOwner vtable (shared by all actors including PlayerCharacter)
+			REL::Relocation<std::uintptr_t> vtbl{ RE::VTABLE::ActorValueOwner[0] };
+			g_origSetBaseAV = reinterpret_cast<SetBaseAV_t*>(vtbl.write_vfunc(4, &HookedSetBaseActorValue));
+			g_origModBaseAV = reinterpret_cast<ModBaseAV_t*>(vtbl.write_vfunc(5, &HookedModBaseActorValue));
+
+			REX::INFO("NegativeHealthFix: ActorValueOwner hooks installed (SetBaseAV + ModBaseAV)"sv);
+		}
+	}
+
+	ModuleNegativeHealthFix::ModuleNegativeHealthFix() :
+		Module("Negative Health Fix", &bFixesNegativeHealthFix)
+	{}
+
+	bool ModuleNegativeHealthFix::DoQuery() const noexcept
+	{
+		return true;
+	}
+
+	bool ModuleNegativeHealthFix::DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		// Install at GameDataReady stage
+		if (a_msg)
+		{
+			if (a_msg->type != F4SE::MessagingInterface::kGameDataReady)
+				return true;
+		}
+
+		negativeHealthFixDetail::InstallHooks();
+		return true;
+	}
+
+	bool ModuleNegativeHealthFix::DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		return true;
+	}
+
+	bool ModuleNegativeHealthFix::DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept
+	{
+		return true;
+	}
+}

--- a/Addictol/Source/Modules/AdModuleNoEssentialDecapitation.cpp
+++ b/Addictol/Source/Modules/AdModuleNoEssentialDecapitation.cpp
@@ -1,0 +1,184 @@
+#include <Modules/AdModuleNoEssentialDecapitation.h>
+#include <AdUtils.h>
+
+#include <RE/N/NiAVObject.h>
+#include <RE/T/TESObjectREFR.h>
+#include <RE/A/Actor.h>
+#include <RE/T/TESNPC.h>
+#include <RE/A/ACTOR_LIFE_STATE.h>
+#include <RE/B/bhkWorld.h>
+
+#include <cstring>
+#include <atomic>
+
+namespace Addictol
+{
+	static REX::TOML::Bool<> bFixesNoEssentialDecapitation{ "Fixes"sv, "bNoEssentialDecapitation"sv, true };
+
+	namespace noEssentialDecapitationDetail
+	{
+		using SetDismemberedLimbFn = bool(RE::NiAVObject*, bool, bool);
+
+		static void* g_trampoline = nullptr;
+
+		static bool Hook_SetDismemberedLimb(RE::NiAVObject* a_object, bool a_tf, bool a_recurse)
+		{
+			auto* tramp = g_trampoline;
+			if (!tramp)
+				return false;
+
+			if (!a_object || !a_tf)
+				return reinterpret_cast<SetDismemberedLimbFn*>(tramp)(a_object, a_tf, a_recurse);
+
+			RE::TESObjectREFR* refr = nullptr;
+			{
+				int guard = 0;
+				for (RE::NiAVObject* node = a_object; node && guard < 16; node = node->parent, ++guard)
+				{
+					const auto ud = node->userData;
+					if (!ud) continue;
+					auto* candidate = reinterpret_cast<RE::TESObjectREFR*>(ud);
+					if (!candidate) continue;
+					const auto ft = candidate->GetFormType();
+					if (ft == RE::ENUM_FORM_ID::kACHR || ft == RE::ENUM_FORM_ID::kREFR)
+					{
+						refr = candidate;
+						break;
+					}
+				}
+			}
+
+			if (refr)
+			{
+				auto* actor = refr->As<RE::Actor>();
+				if (actor)
+				{
+					bool isEss = actor->boolFlags.any(RE::Actor::BOOL_FLAGS::kEssential);
+					bool isProt = actor->boolFlags.any(RE::Actor::BOOL_FLAGS::kProtected);
+
+					if (!isEss && !isProt)
+					{
+						auto* npc = actor->GetNPC();
+						if (npc)
+						{
+							if (!isEss) isEss = npc->IsEssential();
+							if (!isProt) isProt = npc->IsProtected();
+						}
+					}
+
+					if (isEss || isProt)
+					{
+						const auto ls = static_cast<std::uint32_t>(actor->lifeState);
+						const char* name = "(unnamed)";
+						auto* npc2 = actor->GetNPC();
+						if (npc2 && npc2->GetFullName())
+							name = npc2->GetFullName();
+
+						if (isEss)
+						{
+							REX::INFO("NoEssentialDecapitation: BLOCKED Essential \"{}\" (0x{:08X}) lifeState={}"sv,
+								name, actor->GetFormID(), ls);
+							return false;
+						}
+
+						if (ls == static_cast<std::uint32_t>(RE::ACTOR_LIFE_STATE::kDead) ||
+							ls == static_cast<std::uint32_t>(RE::ACTOR_LIFE_STATE::kDying))
+						{
+							REX::INFO("NoEssentialDecapitation: ALLOWED Protected \"{}\" (0x{:08X}) already dead/dying (lifeState={})"sv,
+								name, actor->GetFormID(), ls);
+						}
+						else
+						{
+							REX::INFO("NoEssentialDecapitation: BLOCKED Protected \"{}\" (0x{:08X}) still alive (lifeState={})"sv,
+								name, actor->GetFormID(), ls);
+							return false;
+						}
+					}
+				}
+			}
+
+			return reinterpret_cast<SetDismemberedLimbFn*>(tramp)(a_object, a_tf, a_recurse);
+		}
+
+		// 14-byte absolute JMP helper (FF 25 00 00 00 00 <addr64>)
+		struct JMP14
+		{
+			std::uint8_t  op1 = 0xFF;
+			std::uint8_t  op2 = 0x25;
+			std::uint32_t rel = 0;
+			std::uint64_t addr;
+		};
+		static_assert(sizeof(JMP14) == 14);
+
+		static void InstallHook() noexcept
+		{
+			const auto addr = RE::ID::bhkWorld::SetDismemberedLimb.address();
+			if (!addr)
+			{
+				REX::ERROR("NoEssentialDecapitation: SetDismemberedLimb address resolve failed"sv);
+				return;
+			}
+			REX::INFO("NoEssentialDecapitation: SetDismemberedLimb = 0x{:016X}"sv, addr);
+
+			// 14-byte absolute JMP is position-insensitive, so we can safely relocate
+			// the first 14 bytes of the original function into a trampoline and jump
+			// back to addr+14. This stays compatible with other chain hooks.
+			constexpr std::size_t kJmp14Size = 14;
+			std::byte saved[16]{};
+			auto* target = reinterpret_cast<const std::uint8_t*>(addr);
+			std::memcpy(saved, target, kJmp14Size);
+
+			auto& tramp = REL::GetTrampoline();
+			g_trampoline = tramp.allocate(kJmp14Size + sizeof(JMP14));
+			if (!g_trampoline)
+			{
+				REX::ERROR("NoEssentialDecapitation: trampoline alloc failed"sv);
+				return;
+			}
+
+			std::memcpy(g_trampoline, saved, kJmp14Size);
+			JMP14 jmpBack{};
+			jmpBack.addr = reinterpret_cast<std::uint64_t>(addr + kJmp14Size);
+			std::memcpy(static_cast<std::byte*>(g_trampoline) + kJmp14Size, &jmpBack, sizeof(jmpBack));
+
+			JMP14 jmp14{};
+			jmp14.addr = reinterpret_cast<std::uint64_t>(&Hook_SetDismemberedLimb);
+			REL::WriteSafe(addr, reinterpret_cast<std::byte*>(&jmp14), kJmp14Size);
+
+			std::atomic_thread_fence(std::memory_order_seq_cst);
+			REX::INFO("NoEssentialDecapitation: SetDismemberedLimb hook installed"sv);
+		}
+	}
+
+	ModuleNoEssentialDecapitation::ModuleNoEssentialDecapitation() :
+		Module("No Essential Decapitation", &bFixesNoEssentialDecapitation)
+	{}
+
+	bool ModuleNoEssentialDecapitation::DoQuery() const noexcept
+	{
+		return true;
+	}
+
+	bool ModuleNoEssentialDecapitation::DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		// Install at GameDataReady stage
+		if (a_msg)
+		{
+			if (a_msg->type != F4SE::MessagingInterface::kGameDataReady)
+				return true;
+		}
+
+		noEssentialDecapitationDetail::InstallHook();
+		return true;
+	}
+
+	bool ModuleNoEssentialDecapitation::DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		return true;
+	}
+
+	bool ModuleNoEssentialDecapitation::DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept
+	{
+		return true;
+	}
+}

--- a/Addictol/Source/Modules/AdModuleNoEssentialDecapitation.cpp
+++ b/Addictol/Source/Modules/AdModuleNoEssentialDecapitation.cpp
@@ -2,12 +2,15 @@
 #include <AdUtils.h>
 
 #include <RE/N/NiAVObject.h>
+#include <RE/N/NiNode.h>
+#include <RE/T/TESFormUtil.h>
 #include <RE/T/TESObjectREFR.h>
 #include <RE/A/Actor.h>
 #include <RE/T/TESNPC.h>
 #include <RE/A/ACTOR_LIFE_STATE.h>
 #include <RE/B/bhkWorld.h>
 
+#include <cstdint>
 #include <cstring>
 #include <atomic>
 
@@ -33,7 +36,7 @@ namespace Addictol
 			RE::TESObjectREFR* refr = nullptr;
 			{
 				int guard = 0;
-				for (RE::NiAVObject* node = a_object; node && guard < 16; node = node->parent, ++guard)
+				for (RE::NiAVObject* node = a_object; node && guard < 16; node = reinterpret_cast<RE::NiAVObject*>(node->parent), ++guard)
 				{
 					const auto ud = node->userData;
 					if (!ud) continue;
@@ -101,6 +104,7 @@ namespace Addictol
 		}
 
 		// 14-byte absolute JMP helper (FF 25 00 00 00 00 <addr64>)
+#pragma pack(push, 1)
 		struct JMP14
 		{
 			std::uint8_t  op1 = 0xFF;
@@ -108,6 +112,7 @@ namespace Addictol
 			std::uint32_t rel = 0;
 			std::uint64_t addr;
 		};
+#pragma pack(pop)
 		static_assert(sizeof(JMP14) == 14);
 
 		static void InstallHook() noexcept
@@ -138,7 +143,7 @@ namespace Addictol
 
 			std::memcpy(g_trampoline, saved, kJmp14Size);
 			JMP14 jmpBack{};
-			jmpBack.addr = reinterpret_cast<std::uint64_t>(addr + kJmp14Size);
+			jmpBack.addr = static_cast<std::uint64_t>(addr + kJmp14Size);
 			std::memcpy(static_cast<std::byte*>(g_trampoline) + kJmp14Size, &jmpBack, sizeof(jmpBack));
 
 			JMP14 jmp14{};

--- a/Addictol/Source/Modules/AdModuleWaterJetpackFix.cpp
+++ b/Addictol/Source/Modules/AdModuleWaterJetpackFix.cpp
@@ -3,6 +3,8 @@
 
 #include <RE/P/PlayerCharacter.h>
 #include <RE/A/Actor.h>
+#include <RE/M/MiddleHighProcessData.h>
+#include <RE/B/bhkCharacterController.h>
 
 namespace Addictol
 {

--- a/Addictol/Source/Modules/AdModuleWaterJetpackFix.cpp
+++ b/Addictol/Source/Modules/AdModuleWaterJetpackFix.cpp
@@ -1,0 +1,102 @@
+#include <Modules/AdModuleWaterJetpackFix.h>
+#include <AdUtils.h>
+
+#include <RE/P/PlayerCharacter.h>
+#include <RE/A/Actor.h>
+
+namespace Addictol
+{
+	static REX::TOML::Bool<> bFixesWaterJetpackFix{ "Fixes"sv, "bWaterJetpackFix"sv, true };
+
+	namespace waterJetpackFixDetail
+	{
+		static bool g_wasSwimming = false;
+		static std::uint32_t s_skip = 0;
+
+		static RE::PlayerCharacter* GetPlayerSafe() noexcept
+		{
+			auto handle = RE::PlayerCharacter::GetPlayerHandle();
+			if (!handle) return nullptr;
+			auto ptr = handle.get();
+			return ptr ? static_cast<RE::PlayerCharacter*>(ptr.get()) : nullptr;
+		}
+
+		static void ResetJumpState(RE::PlayerCharacter* a_player) noexcept
+		{
+			if (!a_player->currentProcess || !a_player->currentProcess->middleHigh)
+				return;
+			auto* ctrl = a_player->currentProcess->middleHigh->charController.get();
+			if (!ctrl) return;
+
+			ctrl->flags &= ~0x2000;
+			ctrl->flags |= 0x400;
+			ctrl->fallTime = 0.0f;
+			ctrl->fallStartHeight = 0.0f;
+			ctrl->inAirPreMove = false;
+			ctrl->context.m_currentState = RE::hknpCharacterState::hknpCharacterStateType::kOnGround;
+		}
+
+		static void OnFrameUpdate() noexcept
+		{
+			if (++s_skip < 10) return;
+			s_skip = 0;
+
+			auto* player = GetPlayerSafe();
+			if (!player) return;
+
+			bool isSwimming = player->IsSwimming();
+			if (isSwimming == g_wasSwimming) return;
+
+			if (isSwimming)
+				ResetJumpState(player);
+
+			g_wasSwimming = isSwimming;
+		}
+
+		struct PlayerUpdateHook
+		{
+			static void thunk(RE::Actor* a_this, float a_delta)
+			{
+				func(a_this, a_delta);
+				if (a_this && a_this->IsPlayerRef())
+					OnFrameUpdate();
+			}
+			static inline REL::Relocation<decltype(thunk)> func;
+		};
+	}
+
+	ModuleWaterJetpackFix::ModuleWaterJetpackFix() :
+		Module("Water Jetpack Fix", &bFixesWaterJetpackFix)
+	{}
+
+	bool ModuleWaterJetpackFix::DoQuery() const noexcept
+	{
+		return true;
+	}
+
+	bool ModuleWaterJetpackFix::DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		// Install only at GameDataReady stage (player + process data valid)
+		if (a_msg)
+		{
+			if (a_msg->type != F4SE::MessagingInterface::kGameDataReady)
+				return true;
+		}
+
+		REL::Relocation<std::uintptr_t> vtbl{ RE::VTABLE::PlayerCharacter[0] };
+		waterJetpackFixDetail::PlayerUpdateHook::func = vtbl.write_vfunc(0xCF, waterJetpackFixDetail::PlayerUpdateHook::thunk);
+		REX::INFO("WaterJetpackFix: PlayerCharacter Update hook installed (slot 0xCF)"sv);
+
+		return true;
+	}
+
+	bool ModuleWaterJetpackFix::DoListener([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		return true;
+	}
+
+	bool ModuleWaterJetpackFix::DoPapyrusListener([[maybe_unused]] RE::BSScript::IVirtualMachine* a_vm) noexcept
+	{
+		return true;
+	}
+}

--- a/VC/Addictol.vcxproj
+++ b/VC/Addictol.vcxproj
@@ -68,6 +68,9 @@
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleGreyMovie.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleHighResBloom.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleHUDMessageQueue.cpp" />
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleWaterJetpackFix.cpp" />
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleNoEssentialDecapitation.cpp" />
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleNegativeHealthFix.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleImageSpaceAdapterWarning.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleINISettingCollection.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleInitTints.cpp" />
@@ -165,6 +168,9 @@
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleGreyMovie.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleHighResBloom.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleHUDMessageQueue.h" />
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleWaterJetpackFix.h" />
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleNoEssentialDecapitation.h" />
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleNegativeHealthFix.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleImageSpaceAdapterWarning.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleINISettingCollection.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleInitTints.h" />

--- a/VC/Addictol.vcxproj.filters
+++ b/VC/Addictol.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="..\Addictol\Source\AdAllocator.cpp">
@@ -233,6 +233,15 @@
       <Filter>Source\Modules</Filter>
     </ClCompile>
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleHUDMessageQueue.cpp">
+      <Filter>Source\Modules</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleWaterJetpackFix.cpp">
+      <Filter>Source\Modules</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleNoEssentialDecapitation.cpp">
+      <Filter>Source\Modules</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleNegativeHealthFix.cpp">
       <Filter>Source\Modules</Filter>
     </ClCompile>
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleAltTabFullscreen.cpp">
@@ -527,6 +536,15 @@
       <Filter>Include\Modules</Filter>
     </ClInclude>
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleHUDMessageQueue.h">
+      <Filter>Include\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleWaterJetpackFix.h">
+      <Filter>Include\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleNoEssentialDecapitation.h">
+      <Filter>Include\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleNegativeHealthFix.h">
       <Filter>Include\Modules</Filter>
     </ClInclude>
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleAltTabFullscreen.h">


### PR DESCRIPTION
…tiveHealthFix

Three independent game bug fixes ported as Addictol modules:

1. WaterJetpackFix (bWaterJetpackFix) Fixes a bug where exiting water while using a jetpack leaves the player in a broken jump state. Hooks PlayerCharacter::Update (vtable slot 0xCF) and resets the character controller state when the player transitions into swimming.

2. NoEssentialDecapitation (bNoEssentialDecapitation) Prevents Essential and alive Protected NPCs from being decapitated by scripted or weapon-driven dismemberment. Hooks bhkWorld::SetDismemberedLimb via a 14-byte absolute JMP trampoline and checks both Actor runtime flags and TESNPC base record flags. Essential NPCs are always blocked; Protected NPCs are blocked only while alive (allowed after death).

3. NegativeHealthFix (bNegativeHealthFix) Blocks writes that would set an NPC base health to a negative value, which causes immortal/unkillable actors and health-bar corruption. Hooks ActorValueOwner vtable slots 4 (SetBaseActorValue) and 5 (ModBaseActorValue), intercepting health ActorValue writes and rejecting any that result in a negative base value.

All three modules install at the kGameDataReady stage.