### PR TITLE
remove patch for BSGameDataSystemUtility::IsDLCMasterOrCCFile in tints patch

### DIFF
--- a/Addictol/Source/Modules/AdModuleInitTints.cpp
+++ b/Addictol/Source/Modules/AdModuleInitTints.cpp
@@ -34,9 +34,6 @@ namespace Addictol
 			//else
 			//	RELEX::WriteSafeNop(REL::ID(2192358).address() + 0x47, 0x3B);
 
-			// There are a lot of checks in this function, it was also used in the facegen verification function.
-			// Sets return always 1 or true.		
-			RELEX::WriteSafe(REL::ID(RELEX::IsRuntimeNG() ? 2320239 : 7113302).address(), { 0xB0, 0x01, 0xC3, 0x90, 0x90 });
 			// Skipping the entire section, can't delete the pointer, otherwise will go back to where started.
 			RELEX::WriteSafe(REL::ID(2207492).address() + 0xF3, { 0xE9, 0x7D, 0x00, 0x00, 0x00, 0x90 });
 		}
@@ -54,9 +51,6 @@ namespace Addictol
 			//RELEX::WriteSafeNop(REL::ID(779416).address() + 0x21, 0x19);		
 			//RELEX::WriteSafeNop(REL::ID(1444263).address() + 0x54, 0x19);
 
-			// There are a lot of checks in this function, it was also used in the facegen verification function.
-			// Sets return always 1 or true.		
-			RELEX::WriteSafe(REL::ID(1088335).address(), { 0xB0, 0x01, 0xC3, 0x90, 0x90 });
 			// Skipping the entire section, can't delete the pointer, otherwise will go back to where started.
 			RELEX::WriteSafe(REL::ID(1264833).address() + 0xF9, { 0xE9, 0x9C, 0x00, 0x00, 0x00, 0x90 });
 		}


### PR DESCRIPTION
I was looking at the tints patch and based on testing found that the patching of BSGameDataSystemUtility::IsDLCMasterOrCCFile is not needed.  This function is called in a few places, it is also involved in the tagging of modded savegame metadata, and seems to be involved in the built-in mod manager/plugins writeout functions.

On AE this function is not patched at all because the incorrect address library ID 7113302 is used (correct one is 4506389), so that illustrates that this patch isn't necessary on AE.  And with some testing on OG it's also clear that the existing 3 patch sites is sufficient to allow loading of NPC tinting data and when you disable facegen on an NPC at runtime the engine renders the tints correctly.  Without the tints patch Piper's face will go white if you disable facegen on the NPC.

I tested this with a replaced Actor.ChangeHeadPart papyrus function that sets AddChange(kNPCFace).  Both vanilla and current version of Addictol check for this change flag in CanUsePreprocessedHeads and will disable facegen on the NPC if the flag is set.
