### PR TITLE
Add NPC Health Overflow Fix

### DIFF
--- a/.Build/F4SE/Plugins/Addictol.toml
+++ b/.Build/F4SE/Plugins/Addictol.toml
@@ -256,6 +256,9 @@ bCraftingMenuFix = true
 # Fixes a bug where there is no check for nullptr when AI for a character is disabled.
 bAIProcess3DUpdateFlag = true
 
+# Fixes auto-calculated NPC health and action points wrapping negative on high level NPCs, which could make them drop dead instantly.
+bNPCHealthOverflowFix = true
+
 
 [Warnings]
 

--- a/Addictol/Include/Core/Settings/AdSettings.h
+++ b/Addictol/Include/Core/Settings/AdSettings.h
@@ -87,6 +87,7 @@ namespace Addictol
 	extern BoolSetting bFixesWaterJetpackFix;
 	extern BoolSetting bFixesCraftingMenuFix;
 	extern BoolSetting bFixesAIProcess3DUpdateFlag;
+	extern BoolSetting bFixesNPCHealthOverflowFix;
 
 	extern BoolSetting bWarningsImageSpaceAdapter;
 	extern BoolSetting bWarningsDuplicateAddonNodeIndex;

--- a/Addictol/Include/Modules/AdModuleNPCHealthOverflowFix.h
+++ b/Addictol/Include/Modules/AdModuleNPCHealthOverflowFix.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Core/AdModule.h>
+
+namespace Addictol
+{
+	class ModuleNPCHealthOverflowFix :
+		public Module
+	{
+	public:
+		ModuleNPCHealthOverflowFix();
+		virtual ~ModuleNPCHealthOverflowFix() = default;
+
+		[[nodiscard]] virtual bool DoQuery() const noexcept override;
+		[[nodiscard]] virtual bool DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg = nullptr) noexcept override;
+	};
+}

--- a/Addictol/Source/Core/AdRegisterModules.cpp
+++ b/Addictol/Source/Core/AdRegisterModules.cpp
@@ -89,6 +89,7 @@
 #include <Modules/AdModuleAIProcess3DUpdateFlag.h>
 #include <Modules/AdModuleHighResLocalMaps.h>
 #include <Modules/AdModuleMenu.h>
+#include <Modules/AdModuleNPCHealthOverflowFix.h>
 
 // Create patches
 static auto sModuleThreads							= std::make_shared<Addictol::ModuleThreads>();
@@ -180,6 +181,7 @@ static auto sModuleCraftingMenuFix					= std::make_shared<Addictol::ModuleCrafti
 static auto sModuleAIProcess3DUpdateFlag			= std::make_shared<Addictol::ModuleAIProcess3DUpdateFlag>();
 static auto sModuleHighResLocalMaps					= std::make_shared<Addictol::ModuleHighResLocalMaps>();
 static auto sModuleMenu								= std::make_shared<Addictol::ModuleMenu>();
+static auto sModuleNPCHealthOverflowFix				= std::make_shared<Addictol::ModuleNPCHealthOverflowFix>();
 
 void AdRegisterPreloadModules()
 {
@@ -296,6 +298,7 @@ void AdRegisterModules()
 	modules.Register(sModulePipBoyCursorConstraints,		kGameDataReady);
 	modules.Register(sModuleCompanionStrayBullet,			kGameDataReady);
 	modules.Register(sModuleCraftingMenuFix,				kGameDataReady);
+	modules.Register(sModuleNPCHealthOverflowFix,			kGameDataReady);
 	modules.Register(sModuleEncounterZoneReset,				kGameLoaded);
 	modules.Register(sModuleInputSwitch,					kGameLoaded);
 	modules.Register(sModuleLoadScreen,						kGameLoaded);

--- a/Addictol/Source/Core/Settings/AdFixSettings.cpp
+++ b/Addictol/Source/Core/Settings/AdFixSettings.cpp
@@ -535,4 +535,13 @@ namespace Addictol
 		"Fixes a bug where there is no check for nullptr when AI for a character is disabled."sv,
 		SettingApplyTiming::kNextLaunch
 	};
+
+	BoolSetting bFixesNPCHealthOverflowFix{
+		"Fixes"sv,
+		"bNPCHealthOverflowFix"sv,
+		SettingDisplayCategory::kGameplay,
+		true,
+		"Fixes auto-calculated NPC health and action points wrapping negative on high level NPCs, which could make them drop dead instantly."sv,
+		SettingApplyTiming::kNextLaunch
+	};
 }

--- a/Addictol/Source/Modules/AdModuleNPCHealthOverflowFix.cpp
+++ b/Addictol/Source/Modules/AdModuleNPCHealthOverflowFix.cpp
@@ -1,0 +1,131 @@
+#include <Modules/AdModuleNPCHealthOverflowFix.h>
+#include <Core/AdUtils.h>
+
+#include <RE/A/ActorValueInfo.h>
+#include <RE/A/ActorValueOwner.h>
+#include <RE/T/TESDataHandler.h>
+#include <RE/T/TESNPC.h>
+
+namespace Addictol
+{
+
+	namespace npcHealthOverflowFixDetail
+	{
+		// TESActorBase::ActorValueOwner sub-object, same offset on OG / NG / AE.
+		constexpr std::uintptr_t kAVOwnerInTESNPC = 0x130;
+
+		// Hand-written negative health offsets stay small, the int16 wraparound lands
+		// around -31k, so anything below -1000 is a wrap.
+		constexpr int16_t kNegativeThreshold = -1000;
+
+		// TESNPC::GetActorValue prologue, byte-identical on every runtime:
+		//   mov [rsp+8], rbx ; push rdi ; sub rsp, 0x30 ; mov rbx, rcx
+		inline constexpr std::initializer_list<uint8_t> kPrologue{
+			0x48, 0x89, 0x5C, 0x24, 0x08,
+			0x57,
+			0x48, 0x83, 0xEC, 0x30,
+			0x48, 0x8B, 0xD9 };
+
+		// OG then walks the sub-object pointer back to the NPC, NG / AE just keep going.
+		inline constexpr std::initializer_list<uint8_t> kPrologueTailOG{ 0x48, 0x81, 0xC1, 0xD0, 0xFE, 0xFF, 0xFF };
+		inline constexpr std::initializer_list<uint8_t> kPrologueTailNGAE{ 0x48, 0x8B, 0xFA };
+
+		struct GetActorValue // TESNPC::GetActorValue()
+		{
+			using GetActorValue_t = float (*)(RE::ActorValueOwner* a_this, const RE::ActorValueInfo* a_info);
+
+			static float thunk(RE::ActorValueOwner* a_this, const RE::ActorValueInfo* a_info)
+			{
+				const float result = original(a_this, a_info);
+				if (result >= 0.0F)
+					return result;
+
+				auto* npc = reinterpret_cast<RE::TESNPC*>(
+					reinterpret_cast<std::uintptr_t>(a_this) - kAVOwnerInTESNPC);
+				if (!npc || !npc->HasAutoCalcStats())
+					return result;
+
+				// With auto-calc stats on, the level-derived health / AP seed is stored into an
+				// int16 with no clamping. Past level ~120 the value passes 32767 and wraps, and
+				// the engine sign-extends it, so the NPC's base HP reads as roughly -31k and
+				// it dies to the first hit. The wrap is modular, adding 65536 recovers the
+				// intended value. Matching the returned float against the raw int16 is what
+				// tells us the value really came from the sign extension and not from
+				// race / class / perk additions.
+				const auto health = npc->data.autoCalcHealth;
+				if (health < kNegativeThreshold && result == static_cast<float>(health))
+					return result + 65536.0F;
+
+				const auto actionPoints = npc->data.autoCalcActionPoints;
+				if (actionPoints < kNegativeThreshold && result == static_cast<float>(actionPoints))
+					return result + 65536.0F;
+
+				return result;
+			}
+
+			static inline GetActorValue_t original = nullptr;
+		};
+
+		[[nodiscard]] RE::TESNPC* FindAnyNPC()
+		{
+			auto* handler = RE::TESDataHandler::GetSingleton();
+			if (!handler)
+				return nullptr;
+
+			for (auto* form : handler->formArrays[std::to_underlying(RE::ENUM_FORM_ID::kNPC_)])
+			{
+				if (form)
+					return form->As<RE::TESNPC>();
+			}
+
+			return nullptr;
+		}
+	}
+
+	ModuleNPCHealthOverflowFix::ModuleNPCHealthOverflowFix() :
+		Module("NPC Health Overflow Fix", &bFixesNPCHealthOverflowFix)
+	{}
+
+	bool ModuleNPCHealthOverflowFix::DoQuery() const noexcept
+	{
+		if (IsModDLLPresent("AutoCalcOverflowFix.dll"))
+		{
+			Skip("standalone 'AutoCalcOverflowFix.dll' is installed"sv);
+			return false;
+		}
+
+		return true;
+	}
+
+	bool ModuleNPCHealthOverflowFix::DoInstall([[maybe_unused]] F4SE::MessagingInterface::Message* a_msg) noexcept
+	{
+		if (a_msg && a_msg->type != F4SE::MessagingInterface::kGameDataReady)
+			return true;
+
+		// TESNPC overrides GetActorValue on its ActorValueOwner sub-object, but there is no
+		// address library id for that vtable, so borrow it from a live NPC. Every instance
+		// shares it, one is enough.
+		auto* npc = npcHealthOverflowFixDetail::FindAnyNPC();
+		if (!npc)
+		{
+			Skip("no NPC form found to read the ActorValueOwner vtable from"sv);
+			return false;
+		}
+
+		const auto owner = reinterpret_cast<std::uintptr_t>(npc) + npcHealthOverflowFixDetail::kAVOwnerInTESNPC;
+		const auto vtable = *reinterpret_cast<std::uintptr_t*>(owner);
+		const auto target = *reinterpret_cast<std::uintptr_t*>(vtable + sizeof(void*)); // slot 1
+
+		const auto tail = RELEX::IsRuntimeOG() ? npcHealthOverflowFixDetail::kPrologueTailOG : npcHealthOverflowFixDetail::kPrologueTailNGAE;
+		if (!RELEX::Validate(target, npcHealthOverflowFixDetail::kPrologue) ||
+			!RELEX::Validate(target + npcHealthOverflowFixDetail::kPrologue.size(), tail))
+		{
+			REX::WARN("NPC Health Overflow Fix: unexpected bytes at TESNPC::GetActorValue, skipping to avoid corruption."sv);
+			return false;
+		}
+
+		*((uintptr_t*)&npcHealthOverflowFixDetail::GetActorValue::original) =
+			RELEX::DetourJump(target, reinterpret_cast<uintptr_t>(&npcHealthOverflowFixDetail::GetActorValue::thunk));
+		return npcHealthOverflowFixDetail::GetActorValue::original != nullptr;
+	}
+}

--- a/Addictol/Source/Modules/AdModuleNPCHealthOverflowFix.cpp
+++ b/Addictol/Source/Modules/AdModuleNPCHealthOverflowFix.cpp
@@ -1,6 +1,7 @@
 #include <Modules/AdModuleNPCHealthOverflowFix.h>
 #include <Core/AdUtils.h>
 
+#include <RE/A/ActorValue.h>
 #include <RE/A/ActorValueInfo.h>
 #include <RE/A/ActorValueOwner.h>
 #include <RE/T/TESDataHandler.h>
@@ -11,24 +12,35 @@ namespace Addictol
 
 	namespace npcHealthOverflowFixDetail
 	{
-		// TESActorBase::ActorValueOwner sub-object, same offset on OG / NG / AE.
+		// Verified on OG / NG / AE.
 		constexpr std::uintptr_t kAVOwnerInTESNPC = 0x130;
 
-		// Hand-written negative health offsets stay small, the int16 wraparound lands
-		// around -31k, so anything below -1000 is a wrap.
-		constexpr int16_t kNegativeThreshold = -1000;
-
-		// TESNPC::GetActorValue prologue, byte-identical on every runtime:
-		//   mov [rsp+8], rbx ; push rdi ; sub rsp, 0x30 ; mov rbx, rcx
+		// mov [rsp+8], rbx ; push rdi ; sub rsp, 0x30 ; mov rbx, rcx
 		inline constexpr std::initializer_list<uint8_t> kPrologue{
 			0x48, 0x89, 0x5C, 0x24, 0x08,
 			0x57,
 			0x48, 0x83, 0xEC, 0x30,
 			0x48, 0x8B, 0xD9 };
 
-		// OG then walks the sub-object pointer back to the NPC, NG / AE just keep going.
-		inline constexpr std::initializer_list<uint8_t> kPrologueTailOG{ 0x48, 0x81, 0xC1, 0xD0, 0xFE, 0xFF, 0xFF };
-		inline constexpr std::initializer_list<uint8_t> kPrologueTailNGAE{ 0x48, 0x8B, 0xFA };
+		// add rcx, -0x130 -- the rebase the thunk's arithmetic relies on; OG emits it before mov rdi, rdx and NG / AE after.
+		inline constexpr std::initializer_list<uint8_t> kRebaseThis{ 0x48, 0x81, 0xC1, 0xD0, 0xFE, 0xFF, 0xFF };
+		inline constexpr std::initializer_list<uint8_t> kMovRdiRdx{ 0x48, 0x8B, 0xFA };
+
+		const RE::ActorValueInfo* gHealth{ nullptr };
+		const RE::ActorValueInfo* gActionPoints{ nullptr };
+
+		[[nodiscard]] bool ValidateGetActorValue(std::uintptr_t a_target) noexcept
+		{
+			if (!RELEX::Validate(a_target, kPrologue))
+				return false;
+
+			const auto tail = a_target + kPrologue.size();
+			return RELEX::IsRuntimeOG() ?
+				RELEX::Validate(tail, kRebaseThis) &&
+					RELEX::Validate(tail + kRebaseThis.size(), kMovRdiRdx) :
+				RELEX::Validate(tail, kMovRdiRdx) &&
+					RELEX::Validate(tail + kMovRdiRdx.size(), kRebaseThis);
+		}
 
 		struct GetActorValue // TESNPC::GetActorValue()
 		{
@@ -37,30 +49,22 @@ namespace Addictol
 			static float thunk(RE::ActorValueOwner* a_this, const RE::ActorValueInfo* a_info)
 			{
 				const float result = original(a_this, a_info);
-				if (result >= 0.0F)
+				if (result >= 0.0F || (a_info != gHealth && a_info != gActionPoints))
 					return result;
 
 				auto* npc = reinterpret_cast<RE::TESNPC*>(
 					reinterpret_cast<std::uintptr_t>(a_this) - kAVOwnerInTESNPC);
-				if (!npc || !npc->HasAutoCalcStats())
+				if (!npc->Is(RE::ENUM_FORM_ID::kNPC_) || !npc->HasAutoCalcStats())
 					return result;
 
-				// With auto-calc stats on, the level-derived health / AP seed is stored into an
-				// int16 with no clamping. Past level ~120 the value passes 32767 and wraps, and
-				// the engine sign-extends it, so the NPC's base HP reads as roughly -31k and
-				// it dies to the first hit. The wrap is modular, adding 65536 recovers the
-				// intended value. Matching the returned float against the raw int16 is what
-				// tells us the value really came from the sign extension and not from
-				// race / class / perk additions.
-				const auto health = npc->data.autoCalcHealth;
-				if (health < kNegativeThreshold && result == static_cast<float>(health))
-					return result + 65536.0F;
+				// AutoCalcSkillsAttributes truncates a 32-bit seed into the int16 unclamped; the engine's own accessors read it back with movzx.
+				const auto raw = a_info == gHealth ?
+					npc->data.autoCalcHealth :
+					npc->data.autoCalcActionPoints;
+				if (result != static_cast<float>(raw))
+					return result;
 
-				const auto actionPoints = npc->data.autoCalcActionPoints;
-				if (actionPoints < kNegativeThreshold && result == static_cast<float>(actionPoints))
-					return result + 65536.0F;
-
-				return result;
+				return static_cast<float>(static_cast<std::uint16_t>(raw));
 			}
 
 			static inline GetActorValue_t original = nullptr;
@@ -72,10 +76,10 @@ namespace Addictol
 			if (!handler)
 				return nullptr;
 
-			for (auto* form : handler->formArrays[std::to_underlying(RE::ENUM_FORM_ID::kNPC_)])
+			for (auto* npc : handler->GetFormArray<RE::TESNPC>())
 			{
-				if (form)
-					return form->As<RE::TESNPC>();
+				if (npc)
+					return npc;
 			}
 
 			return nullptr;
@@ -102,9 +106,14 @@ namespace Addictol
 		if (a_msg && a_msg->type != F4SE::MessagingInterface::kGameDataReady)
 			return true;
 
-		// TESNPC overrides GetActorValue on its ActorValueOwner sub-object, but there is no
-		// address library id for that vtable, so borrow it from a live NPC. Every instance
-		// shares it, one is enough.
+		auto* actorValues = RE::ActorValue::GetSingleton();
+		if (!actorValues || !actorValues->health || !actorValues->actionPoints)
+		{
+			Skip("actor value list is unavailable"sv);
+			return false;
+		}
+
+		// VTABLE::TESNPC[6] is REL::ID(235917), which resolves to the wrong address on AE, where the real vtable has no id.
 		auto* npc = npcHealthOverflowFixDetail::FindAnyNPC();
 		if (!npc)
 		{
@@ -112,17 +121,25 @@ namespace Addictol
 			return false;
 		}
 
-		const auto owner = reinterpret_cast<std::uintptr_t>(npc) + npcHealthOverflowFixDetail::kAVOwnerInTESNPC;
+		// Take the sub-object offset from the compiler instead of trusting the literal.
+		const auto owner = reinterpret_cast<std::uintptr_t>(static_cast<RE::ActorValueOwner*>(npc));
+		if (owner - reinterpret_cast<std::uintptr_t>(npc) != npcHealthOverflowFixDetail::kAVOwnerInTESNPC)
+		{
+			Skip("TESNPC ActorValueOwner sub-object is not at the expected offset"sv);
+			return false;
+		}
+
 		const auto vtable = *reinterpret_cast<std::uintptr_t*>(owner);
 		const auto target = *reinterpret_cast<std::uintptr_t*>(vtable + sizeof(void*)); // slot 1
 
-		const auto tail = RELEX::IsRuntimeOG() ? npcHealthOverflowFixDetail::kPrologueTailOG : npcHealthOverflowFixDetail::kPrologueTailNGAE;
-		if (!RELEX::Validate(target, npcHealthOverflowFixDetail::kPrologue) ||
-			!RELEX::Validate(target + npcHealthOverflowFixDetail::kPrologue.size(), tail))
+		if (!npcHealthOverflowFixDetail::ValidateGetActorValue(target))
 		{
-			REX::WARN("NPC Health Overflow Fix: unexpected bytes at TESNPC::GetActorValue, skipping to avoid corruption."sv);
+			Skip("unexpected bytes at TESNPC::GetActorValue"sv);
 			return false;
 		}
+
+		npcHealthOverflowFixDetail::gHealth = actorValues->health;
+		npcHealthOverflowFixDetail::gActionPoints = actorValues->actionPoints;
 
 		*((uintptr_t*)&npcHealthOverflowFixDetail::GetActorValue::original) =
 			RELEX::DetourJump(target, reinterpret_cast<uintptr_t>(&npcHealthOverflowFixDetail::GetActorValue::thunk));

--- a/VC/Addictol.vcxproj
+++ b/VC/Addictol.vcxproj
@@ -61,6 +61,7 @@
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleSaveCompression.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleDpiScaling.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleMusicOverlap.cpp" />
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleNPCHealthOverflowFix.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleProcessIcon.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModulePuddleCubemaps.cpp" />
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleStringPoolRelease.cpp" />
@@ -189,6 +190,7 @@
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleSaveCompression.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleDpiScaling.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleMusicOverlap.h" />
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleNPCHealthOverflowFix.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleProcessIcon.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModulePuddleCubemaps.h" />
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleStringPoolRelease.h" />

--- a/VC/Addictol.vcxproj.filters
+++ b/VC/Addictol.vcxproj.filters
@@ -265,6 +265,9 @@
     <ClCompile Include="..\Addictol\Source\Modules\AdModuleMuzzleFlashLight.cpp">
       <Filter>Source\Modules\M</Filter>
     </ClCompile>
+    <ClCompile Include="..\Addictol\Source\Modules\AdModuleNPCHealthOverflowFix.cpp">
+      <Filter>Source\Modules\N</Filter>
+    </ClCompile>
     <ClCompile Include="..\Addictol\Source\Modules\AdModulePackageAllocateLocation.cpp">
       <Filter>Source\Modules\P</Filter>
     </ClCompile>
@@ -637,6 +640,9 @@
     <ClInclude Include="..\Addictol\Include\Modules\AdModuleMuzzleFlashLight.h">
       <Filter>Include\Modules\M</Filter>
     </ClInclude>
+    <ClInclude Include="..\Addictol\Include\Modules\AdModuleNPCHealthOverflowFix.h">
+      <Filter>Include\Modules\N</Filter>
+    </ClInclude>
     <ClInclude Include="..\Addictol\Include\Modules\AdModulePackageAllocateLocation.h">
       <Filter>Include\Modules\P</Filter>
     </ClInclude>
@@ -840,6 +846,9 @@
     <Filter Include="Source\Modules\M">
       <UniqueIdentifier>{4bf4ef20-3f27-4726-8eed-29475563cbe1}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source\Modules\N">
+      <UniqueIdentifier>{7a3c9d1e-5b24-4e8f-9c47-2d61e8a9b0f3}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Source\Modules\P">
       <UniqueIdentifier>{ce084078-3a41-4d40-b54a-7b327199e685}</UniqueIdentifier>
     </Filter>
@@ -893,6 +902,9 @@
     </Filter>
     <Filter Include="Include\Modules\M">
       <UniqueIdentifier>{b99f2740-8b50-4811-953b-348fe15149f8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Include\Modules\N">
+      <UniqueIdentifier>{b9e4f2a8-1c7d-4a63-8e52-93f0c5d2a481}</UniqueIdentifier>
     </Filter>
     <Filter Include="Include\Modules\P">
       <UniqueIdentifier>{020887d5-4a7a-44fc-9980-b9786a7f611a}</UniqueIdentifier>


### PR DESCRIPTION
Ported this straight from my mod. autoCalcHealth is an int16, so when a value gets added in one go and it's too big, it overflows and goes negative.
I didn't do the DearModdingUI compatibility part, so I might need you guys to take care of that.